### PR TITLE
drop support for nodejs 11.x; at time of writing it is an unstable beta ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"
 notifications:
   flowdock: f0bbceadacc5c97e7f3a657941b5a5eb

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-pelias-openstreetmap
-====================
+
+## Install dependencies
+
+```bash
+$ npm install
+```
+
+## Contributing
+
+Please fork and pull request against upstream master on a feature branch.
+
+Pretty please; provide unit tests and script fixtures in the `test` directory.
+
+### Running Unit Tests
+
+```bash
+$ npm test
+```
+
+### Continuous Integration
+
+Travis tests every release against node version `0.10`
+
+[![Build Status](https://travis-ci.org/mapzen/pelias-openstreetmap.png?branch=master)](https://travis-ci.org/mapzen/pelias-openstreetmap)


### PR DESCRIPTION
...and leveldown doesn't compile correctly on 11.x yet
