### PR TITLE
store all admin fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ node_fork
 
   // remove tags not in schema (or throws StrictDynamicMappingException)
   // note: 'tags' are being stripped to reduce db size
-  .pipe( propStream.whitelist(['id','name','address','type','admin0','admin1','admin2','center_point','suggest']) )
+  .pipe( propStream.whitelist(['id','name','address','type','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','suggest']) )
 
   .pipe( stats( 'node_blacklist -> es_osmnode_backend' ) )
   .pipe( backend.es.osmnode.createPullStream() );
@@ -188,7 +188,7 @@ way_fork
 
   // remove tags not in schema (or throws StrictDynamicMappingException)
   // note: 'tags' are being stripped to reduce db size
-  .pipe( propStream.whitelist(['id','name','address','type','admin0','admin1','admin2','center_point','suggest']) )
+  .pipe( propStream.whitelist(['id','name','address','type','alpha3','admin0','admin1','admin1_abbr','admin2','local_admin','locality','neighborhood','center_point','suggest']) )
 
   .pipe( stats( 'way_blacklist -> es_osmway_backend' ) )
   .pipe( backend.es.osmway.createPullStream() );


### PR DESCRIPTION
store all admin fields on record as per https://github.com/pelias/schema/pull/17

eg:

``` javascript
{
  "_index": "pelias",
  "_type": "osmnode",
  "_id": "address-node-42752609",
  "_version": 1,
  "found": true,
  "_source": {
    "name": {
      "default": "2103 Saint Paul Avenue"
    },
    "type": "node",
    "center_point": {
      "lat": 40.8541193,
      "lon": -73.8298641
    },
    "alpha3": "USA",
    "admin0": "United States",
    "admin1": "New York",
    "admin1_abbr": "NY",
    "admin2": "Bronx",
    "local_admin": "Bronx",
    "locality": "New York",
    "neighborhood": "Pelham Bay",
    "suggest": {
      "input": [
        "2103 saint paul avenue"
      ],
      "payload": {
        "id": "osmnode\/address-node-42752609",
        "geo": "-73.82986410000001,40.8541193"
      },
      "output": "2103 Saint Paul Avenue, Bronx, NY",
      "weight": 4
    }
  }
}
```
