### PR TITLE
Error handling

### DIFF
--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -88,6 +88,7 @@ module.exports = function(){
     catch( e ){
       console.error( 'address_extractor error' );
       console.error( e.stack );
+      console.error( JSON.stringify( doc, null, 2 ) );
     }
 
     return next();

--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -29,59 +29,69 @@ var through = require('through2'),
     Document = require('pelias-model').Document,
     idOrdinal = 0; // used for addresses lacking an id (to keep them unique)
 
-function hasValidAddress( item ){
-  if( !isObject( item ) ){ return false; }
-  if( !isObject( item.address ) ){ return false; }
-  if( 'string' !== typeof item.address.number ){ return false; }
-  if( 'string' !== typeof item.address.street ){ return false; }
-  if( !item.address.number.length ){ return false; }
-  if( !item.address.street.length ){ return false; }
+function hasValidAddress( doc ){
+  if( !isObject( doc ) ){ return false; }
+  if( !isObject( doc.address ) ){ return false; }
+  if( 'string' !== typeof doc.address.number ){ return false; }
+  if( 'string' !== typeof doc.address.street ){ return false; }
+  if( !doc.address.number.length ){ return false; }
+  if( !doc.address.street.length ){ return false; }
   return true;
 }
 
 module.exports = function(){
 
-  var stream = through.obj( function( item, enc, done ) {
+  var stream = through.obj( function( doc, enc, next ) {
 
-    var isNamedPoi = !!item.getName('default');
+    try {
 
-    // create a new record for street addresses
-    if( hasValidAddress( item ) ){
-      var type = isNamedPoi ? 'poi-address' : 'address';
+      var isNamedPoi = !!doc.getName('default');
 
-      // copy data to new document
-      var record = new Document( 'osmaddress', type + '-' + item.getType() + '-' + (item.getId() || ++idOrdinal) );
+      // create a new record for street addresses
+      if( hasValidAddress( doc ) ){
+        var type = isNamedPoi ? 'poi-address' : 'address';
 
-      record
-        .setName( 'default', item.address.number + ' ' + item.address.street )
-        .setCentroid( item.getCentroid() );
+        // copy data to new document
+        var record = new Document( 'osmaddress', type + '-' + doc.getType() + '-' + (doc.getId() || ++idOrdinal) );
 
-      // copy address info
-      record.address = item.address;
+        record
+          .setName( 'default', doc.address.number + ' ' + doc.address.street )
+          .setCentroid( doc.getCentroid() );
 
-      // copy admin data
-      if( item.alpha3 ){ record.setAlpha3( item.alpha3 ); }
-      if( item.admin0 ){ record.setAdmin( 'admin0', item.admin0 ); }
-      if( item.admin1 ){ record.setAdmin( 'admin1', item.admin1 ); }
-      if( item.admin1_abbr ){ record.setAdmin( 'admin1_abbr', item.admin1_abbr ); }
-      if( item.admin2 ){ record.setAdmin( 'admin2', item.admin2 ); }
-      if( item.local_admin ){ record.setAdmin( 'local_admin', item.local_admin ); }
-      if( item.locality ){ record.setAdmin( 'locality', item.locality ); }
-      if( item.neighborhood ){ record.setAdmin( 'neighborhood', item.neighborhood ); }
-      
-      // copy meta data (but maintain the id & type assigned above)
-      record._meta = extend( true, {}, item._meta, { id: record.getId(), type: record.getType() } );
+        // copy address info
+        record.address = doc.address;
 
-      this.push( record );
+        // copy admin data
+        if( doc.alpha3 ){ record.setAlpha3( doc.alpha3 ); }
+        if( doc.admin0 ){ record.setAdmin( 'admin0', doc.admin0 ); }
+        if( doc.admin1 ){ record.setAdmin( 'admin1', doc.admin1 ); }
+        if( doc.admin1_abbr ){ record.setAdmin( 'admin1_abbr', doc.admin1_abbr ); }
+        if( doc.admin2 ){ record.setAdmin( 'admin2', doc.admin2 ); }
+        if( doc.local_admin ){ record.setAdmin( 'local_admin', doc.local_admin ); }
+        if( doc.locality ){ record.setAdmin( 'locality', doc.locality ); }
+        if( doc.neighborhood ){ record.setAdmin( 'neighborhood', doc.neighborhood ); }
+
+        // copy meta data (but maintain the id & type assigned above)
+        record._meta = extend( true, {}, doc._meta, { id: record.getId(), type: record.getType() } );
+
+        this.push( record );
+      }
+
+      // forward doc downstream is it's a POI in it's own right
+      // note: this MUST be below the address push()
+      if( isNamedPoi ){
+        this.push( doc );
+      }
+
     }
 
-    // forward item downstream is it's a POI in it's own right
-    // note: this MUST be below the address push()
-    if( isNamedPoi ){
-      this.push( item );
+    catch( e ){
+      console.error( 'address_extractor error' );
+      console.error( e.stack );
     }
 
-    return done();
+    return next();
+
   });
 
   // catch stream errors

--- a/stream/category_mapper.js
+++ b/stream/category_mapper.js
@@ -56,6 +56,7 @@ module.exports = function( mapping ){
     catch( e ){
       console.error( 'category_mapper error' );
       console.error( e.stack );
+      console.error( JSON.stringify( doc, null, 2 ) );
     }
 
     return next( null, doc );

--- a/stream/category_mapper.js
+++ b/stream/category_mapper.js
@@ -19,22 +19,24 @@ module.exports = function( mapping ){
 
   return through.obj( function( doc, enc, next ){
 
-    // do not categorize addresses
-    if( doc.getId().match('address') ){
-      return next( null, doc );
-    }
+    try {
 
-    // skip records with no tags
-    var tags = doc.getMeta('tags');
-    if( !tags ){
-      return next( null, doc );
-    }
+      // do not categorize addresses
+      if( doc.getId().match('address') ){
+        return next( null, doc );
+      }
 
-    // iterate over mapping
-    for( var key in mapping ){
+      // skip records with no tags
+      var tags = doc.getMeta('tags');
+      if( !tags ){
+        return next( null, doc );
+      }
 
-      // check each mapping key against document tags
-      if( tags.hasOwnProperty( key ) ){
+      // iterate over mapping
+      for( var key in mapping ){
+
+        // check each mapping key against document tags
+        if( !tags.hasOwnProperty( key ) ){ continue; }
 
         // handle mapping wildcards
         if( mapping[key].hasOwnProperty('*') ){
@@ -49,6 +51,11 @@ module.exports = function( mapping ){
           }
         }
       }
+    }
+
+    catch( e ){
+      console.error( 'category_mapper error' );
+      console.error( e.stack );
     }
 
     return next( null, doc );

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -18,10 +18,15 @@ var ADDRESS_SCHEMA = merge( true, false,
 
 module.exports = function(){
 
-  var stream = through.obj( function( doc, enc, done ) {
+  var stream = through.obj( function( doc, enc, next ) {
 
-    var tags = doc.getMeta('tags');
-    if( tags ){
+    try {
+
+      // skip records with no tags
+      var tags = doc.getMeta('tags');
+      if( !tags ){
+        return next( null, doc );
+      }
 
       // Unfortunately we need to iterate over every tag,
       // so we only do the iteration once to save CPU.
@@ -55,8 +60,12 @@ module.exports = function(){
       }
     }
 
-    this.push( doc );
-    done();
+    catch( e ){
+      console.error( 'tag_mapper error' );
+      console.error( e.stack );
+    }
+
+    return next( null, doc );
 
   });
 

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -63,6 +63,7 @@ module.exports = function(){
     catch( e ){
       console.error( 'tag_mapper error' );
       console.error( e.stack );
+      console.error( JSON.stringify( doc, null, 2 ) );
     }
 
     return next( null, doc );

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -68,7 +68,7 @@ module.exports = function(){
 
 // Clean string of leading/trailing junk chars
 function trim( str ){
-  return trimmer( str, '#$%^*()<>-=_{};:",./?\' ' );
+  return trimmer( str, '#$%^*()<>-=_{};:",./?\t\n\' ' );
 }
 
 // extract name suffix, eg for 'name:EN' return 'en'

--- a/test/stream/address_extractor.js
+++ b/test/stream/address_extractor.js
@@ -1,6 +1,7 @@
 
 var extractor = require('../../stream/address_extractor'),
     fixtures = require('../fixtures/docs'),
+    Document = require('pelias-model').Document,
     through = require('through2');
 
 module.exports.tests = {};
@@ -209,6 +210,26 @@ module.exports.tests.duplicateAllFields = function(test, common) {
       next();
     }));
     stream.write(fixtures.completeDoc);
+  });
+};
+
+// ======================= errors ========================
+
+// catch general errors in the stream, emit logs and discard the doc
+module.exports.tests.catch_thrown_errors = function(test, common) {
+  test('errors - catch thrown errors', function(t) {
+    var doc = new Document('a',1);
+
+    // this method will throw a generic Error for testing
+    doc.getName = function(){ throw new Error('test'); };
+
+    var stream = extractor();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.end(); // test will fail if called (called twice).
+      next();
+    }));
+    stream.write(doc);
+    t.end();
   });
 };
 

--- a/test/stream/category_mapper.js
+++ b/test/stream/category_mapper.js
@@ -169,6 +169,24 @@ module.exports.tests.argentinian_steak_restaurant = function(test, common) {
 
 // ======================= errors ========================
 
+// catch general errors in the stream, emit logs and passthrough the doc
+module.exports.tests.catch_thrown_errors = function(test, common) {
+  test('errors - catch thrown errors', function(t) {
+    var doc = new Document('a',1);
+
+    // this method will throw a generic Error for testing
+    doc.getMeta = function(){ throw new Error('test'); };
+
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual( doc.getType(), 'a', 'doc passthrough' );
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 module.exports.tests.empty_tag_value = function(test, common) {
   test('errors - ignore empty tags', function(t) {
     var doc = new Document('a',1);

--- a/test/stream/category_mapper.js
+++ b/test/stream/category_mapper.js
@@ -167,6 +167,50 @@ module.exports.tests.argentinian_steak_restaurant = function(test, common) {
   });
 };
 
+// ======================= errors ========================
+
+module.exports.tests.empty_tag_value = function(test, common) {
+  test('errors - ignore empty tags', function(t) {
+    var doc = new Document('a',1);
+    doc.setMeta('tags', { 'cuisine': '' });
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual(doc.category, [], 'ignore empty tags');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.tab_only_value = function(test, common) {
+  var doc = new Document('a',1);
+  doc.setMeta('tags', { 'cuisine': '\t' });
+  test('errors - tab only value', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual(doc.category, [], 'remove tabs');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.newline_only_value = function(test, common) {
+  var doc = new Document('a',1);
+  doc.setMeta('tags', { 'cuisine': '\n' });
+  test('errors - newline only value', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual(doc.category, [], 'remove newlines');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -202,13 +202,71 @@ module.exports.tests.trim_junk = function(test, common) {
   });
 };
 
-module.exports.tests.empty_tags = function(test, common) {
-  test('clean - ignore empty tags', function(t) {
+// ======================= errors ========================
+
+module.exports.tests.empty_tag_value = function(test, common) {
+  test('errors - ignore empty tags', function(t) {
     var doc = new Document('a',1);
     doc.setMeta('tags', { name: '' });
     var stream = mapper();
     stream.pipe( through.obj( function( doc, enc, next ){
       t.equal(doc.getName('default'), undefined, 'ignore empty tags');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.tab_only_value = function(test, common) {
+  var doc = new Document('a',1);
+  doc.setMeta('tags', { 'name': '\t' });
+  test('errors - tab only value', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal(doc.getName('default'), undefined, 'remove tabs');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.tab_in_value = function(test, common) {
+  var doc = new Document('a',1);
+  doc.setMeta('tags', { 'name': '\tfoo\t' });
+  test('errors - tab in value', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal(doc.getName('default'), 'foo', 'remove tabs');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.newline_only_value = function(test, common) {
+  var doc = new Document('a',1);
+  doc.setMeta('tags', { 'name': '\n' });
+  test('errors - newline only value', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal(doc.getName('default'), undefined, 'remove newlines');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.newline_in_value = function(test, common) {
+  var doc = new Document('a',1);
+  doc.setMeta('tags', { 'name': '\nfoo\n' });
+  test('errors - newline in value', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal(doc.getName('default'), 'foo', 'remove newlines');
       t.end(); // test will fail if not called (or called twice).
       next();
     }));

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -204,6 +204,24 @@ module.exports.tests.trim_junk = function(test, common) {
 
 // ======================= errors ========================
 
+// catch general errors in the stream, emit logs and passthrough the doc
+module.exports.tests.catch_thrown_errors = function(test, common) {
+  test('errors - catch thrown errors', function(t) {
+    var doc = new Document('a',1);
+
+    // this method will throw a generic Error for testing
+    doc.getMeta = function(){ throw new Error('test'); };
+
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual( doc.getType(), 'a', 'doc passthrough' );
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 module.exports.tests.empty_tag_value = function(test, common) {
   test('errors - ignore empty tags', function(t) {
     var doc = new Document('a',1);


### PR DESCRIPTION
A bunch of improvements regarding error handling:

- gracefully handle newline and tab characters in OSM tag values
- catch generic thrown errors in stream transform functions

Plus some minor tweaks:

- rename `item` to `doc` for consistency ($doc represents a `pelias/model.Document` object)
- rename `done` to `next`, again for consistency
- flatten some nested code to reduce cyclomatic complexity
- add more tests to cover more edge-cases