### PR TITLE
Replace use of console with pelias-logger.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pelias-model": "^0.3.0",
     "pelias-suggester-pipeline": "^2.0.3",
     "through2": "^0.6.3",
+    "pelias-logger": "^0.0.8",
     "trimmer": "^1.0.0"
   },
   "devDependencies": {

--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -26,6 +26,7 @@
 var through = require('through2'),
     isObject = require('is-object'),
     extend = require('extend'),
+    peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' ),
     Document = require('pelias-model').Document,
     idOrdinal = 0; // used for addresses lacking an id (to keep them unique)
 
@@ -75,9 +76,9 @@ module.exports = function(){
         });
       }
       catch( e ){
-        console.error( 'address_extractor error' );
-        console.error( e.stack );
-        console.error( JSON.stringify( doc, null, 2 ) );
+        peliasLogger.error( 'address_extractor error' );
+        peliasLogger.error( e.stack );
+        peliasLogger.error( JSON.stringify( doc, null, 2 ) );
       }
 
       if( record !== undefined ){
@@ -98,7 +99,7 @@ module.exports = function(){
   });
 
   // catch stream errors
-  stream.on( 'error', console.error.bind( console, __filename ) );
+  stream.on( 'error', peliasLogger.error.bind( peliasLogger, __filename ) );
 
   return stream;
 };

--- a/stream/category_mapper.js
+++ b/stream/category_mapper.js
@@ -14,6 +14,7 @@
 **/
 
 var through = require('through2');
+var peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
 
 module.exports = function( mapping ){
 
@@ -54,9 +55,9 @@ module.exports = function( mapping ){
     }
 
     catch( e ){
-      console.error( 'category_mapper error' );
-      console.error( e.stack );
-      console.error( JSON.stringify( doc, null, 2 ) );
+      peliasLogger.error( 'category_mapper error' );
+      peliasLogger.error( e.stack );
+      peliasLogger.error( JSON.stringify( doc, null, 2 ) );
     }
 
     return next( null, doc );

--- a/stream/denormalizer.js
+++ b/stream/denormalizer.js
@@ -10,7 +10,8 @@
 var through = require('through2'),
     isObject = require('is-object'),
     geoJsonCenter = require('../util/geoJsonCenter'),
-    geoJsonTypeFor = require('../util/geoJsonTypeFor');
+    geoJsonTypeFor = require('../util/geoJsonTypeFor'),
+    peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
 
 // convert de-normalized ways to geojson
 function denormalizer(){
@@ -45,7 +46,7 @@ function denormalizer(){
       next();
 
     } catch( e ){
-      console.log( 'failed to denormalize way', e );
+      peliasLogger.error( 'failed to denormalize way', e );
       next();
     }
   });

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -5,7 +5,8 @@
 **/
 
 var through = require('through2'),
-    Document = require('pelias-model').Document;
+    Document = require('pelias-model').Document,
+    peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
 
 module.exports = function(){
 
@@ -35,7 +36,7 @@ module.exports = function(){
     }
 
     catch( e ){
-      console.error( 'error constructing document model', e.stack );
+      peliasLogger.error( 'error constructing document model', e.stack );
     }
 
     return next();
@@ -43,7 +44,7 @@ module.exports = function(){
   });
 
   // catch stream errors
-  stream.on( 'error', console.error.bind( console, __filename ) );
+  stream.on( 'error', peliasLogger.error.bind( peliasLogger, __filename ) );
 
   return stream;
 };

--- a/stream/stats.js
+++ b/stream/stats.js
@@ -14,7 +14,8 @@
 
   you can then get throughput statistics in your terminal to identify bottlenecks:
 
-    setInterval( console.log.bind( console, stats.metrics ), 1000 );
+    var peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
+    setInterval( peliasLogger.log.bind( peliasLogger, stats.metrics ), 1000 );
 **/
 
 var through = require('through2');

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -6,7 +6,8 @@
 
 var through = require('through2'),
     trimmer = require('trimmer'),
-    merge = require('merge');
+    merge = require('merge'),
+    peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
 
 var LOCALIZED_NAME_KEYS = require('../config/localized_name_keys');
 var NAME_SCHEMA = require('../schema/name_osm');
@@ -61,9 +62,9 @@ module.exports = function(){
     }
 
     catch( e ){
-      console.error( 'tag_mapper error' );
-      console.error( e.stack );
-      console.error( JSON.stringify( doc, null, 2 ) );
+      peliasLogger.error( 'tag_mapper error' );
+      peliasLogger.error( e.stack );
+      peliasLogger.error( JSON.stringify( doc, null, 2 ) );
     }
 
     return next( null, doc );
@@ -71,7 +72,7 @@ module.exports = function(){
   });
 
   // catch stream errors
-  stream.on( 'error', console.error.bind( console, __filename ) );
+  stream.on( 'error', peliasLogger.error.bind( peliasLogger, __filename ) );
 
   return stream;
 };


### PR DESCRIPTION
Resolve #36 .

```
package.json
	-Add `pelias-logger` as a dependency.

stream/(address_extractor, category_mapper, denormalizer, document_constructor, stats, tag_mapper).js
	-Replace all usage of `console` with `pelias-logger`.
```