### PR TITLE
upgrade pbf2json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "is-object": "^1.0.1",
     "iso-639-3": "^0.2.0",
     "merge": "^1.2.0",
-    "pbf2json": "^2.4.0",
+    "pbf2json": "^3.0.0",
     "pelias-admin-lookup": "^2.0.8",
     "pelias-config": "latest",
     "pelias-dbclient": "0.0.9",

--- a/stream/denormalizer.js
+++ b/stream/denormalizer.js
@@ -24,19 +24,26 @@ function denormalizer(){
 
     try {
 
-      var nodes = doc.getMeta('nodes');
-      if( !nodes ){ return next(); }
+      // only compute centroids where they have not already
+      // been computed (avoid doing double work)
+      if( 'number' !== typeof doc.getLat() || 'number' !== typeof doc.getLon() ){
 
-      var points = nodes.map( function( doc ){
-        return {
-          longitude: doc.lon,
-          latitude: doc.lat
-        };
-      });
+        var nodes = doc.getMeta('nodes');
+        if( nodes ){
 
-      var center = geoJsonCenter( points );
-      if( isObject( center ) ){
-        doc.setCentroid( center );
+          var points = nodes.map( function( doc ){
+            return {
+              longitude: doc.lon,
+              latitude: doc.lat
+            };
+          });
+
+          var center = geoJsonCenter( points );
+          if( isObject( center ) ){
+            doc.setCentroid( center );
+          }
+        }
+
       }
 
       this.push( doc );

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -23,6 +23,16 @@ module.exports = function(){
         });
       }
 
+      // Set latitude / longitude (for ways where the centroid has been precomputed)
+      else if( item.hasOwnProperty('centroid') ){
+        if( item.centroid.hasOwnProperty('lat') && item.centroid.hasOwnProperty('lon') ){
+          doc.setCentroid({
+            lat: item.centroid.lat,
+            lon: item.centroid.lon
+          });
+        }
+      }
+
       // Set noderefs (for ways)
       if( item.hasOwnProperty('nodes') ){
         doc.setMeta( 'nodes', item.nodes );

--- a/test/fixtures/docs.js
+++ b/test/fixtures/docs.js
@@ -50,16 +50,14 @@ docs.osmNode1 = new Document('item7',7)
   .setName('osmnode','node7')
   .setCentroid({lat:7,lon:7});
 
-docs.osmWay1 = new Document('item8',8)
+docs.osmWay1 = new Document('osmway',8)
   .setName('osmway','way8')
-  .setCentroid({lat:8,lon:8});
-
-docs.osmWay1.nodes = [
-  { lat: 10, lon: 10 },
-  { lat: 06, lon: 10 },
-  { lat: 06, lon: 06 },
-  { lat: 10, lon: 06 }
-];
+  .setMeta('nodes', [
+    { lat: 10, lon: 10 },
+    { lat: 06, lon: 10 },
+    { lat: 06, lon: 06 },
+    { lat: 10, lon: 06 }
+  ]);
 
 docs.osmRelation1 = new Document('item9',9)
   .setName('osmrelation','relation9')
@@ -72,5 +70,10 @@ docs.semicolonStreetNumbers.setCentroid({lat:10,lon:10});
 docs.semicolonStreetNumbers.address = {
   number: '1; 2 ;3', street: 'Pennine Road'
 };
+
+// has no 'nodes' and a preset centroid
+docs.osmWay2 = new Document('osmway',11)
+  .setName('osmway','way11')
+  .setCentroid({lat:11,lon:11});
 
 module.exports = docs;

--- a/test/stream/denormalizer.js
+++ b/test/stream/denormalizer.js
@@ -44,15 +44,27 @@ module.exports.tests.passthrough = function(test, common) {
 
 // compute centroid for ways
 module.exports.tests.computeWayCentroid = function(test, common) {
-  test('passthrough: nodes', function(t) {
+  test('compute centroid: nodes', function(t) {
     var stream = denormalizer();
     stream.pipe( through.obj( function( doc, enc, next ){
-      t.equal( doc, fixtures.osmWay1, 'no-op for nodes' );
-      t.deepEqual( doc.getCentroid(), { lat: 8, lon: 8 }, 'centroid computed' );
+      t.deepEqual( doc.getCentroid(), { lat: 8.004813, lon: 8 }, 'centroid computed' );
       t.end(); // test will fail if not called (or called twice).
       next();
     }));
     stream.write(fixtures.osmWay1);
+  });
+};
+
+// skip computing centroid where centroid info already available in src
+module.exports.tests.skipComputeWayCentroid = function(test, common) {
+  test('compute centroid: skip', function(t) {
+    var stream = denormalizer();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual( doc.getCentroid(), { lat: 11, lon: 11 }, 'centroid computed' );
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(fixtures.osmWay2);
   });
 };
 

--- a/test/stream/document_constructor.js
+++ b/test/stream/document_constructor.js
@@ -78,6 +78,24 @@ module.exports.tests.centroid = function(test, common) {
     }));
     stream.write({ id: 1, type: 'X', lat: 0, lon: 0 });
   });
+  test('centroid: from preprocessed centroid property', function(t) {
+    var stream = constructor();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual( doc.getCentroid(), { lat: 1, lon: 2 }, 'accepts centroid property' );
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write({ id: 1, type: 'X', centroid: { lat: 1, lon: 2 } } );
+  });
+  test('centroid: prefers lat/lon to centroid', function(t) {
+    var stream = constructor();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual( doc.getCentroid(), { lat: 1, lon: 1 }, 'prefers lat/lon' );
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write({ id: 1, type: 'X', lat: 1, lon: 1, centroid: { lat: 2, lon: 2 } } );
+  });
 };
 
 module.exports.tests.noderefs = function(test, common) {


### PR DESCRIPTION
bring osm importer up-to-date with latest changes to `osm2pbf`, see https://github.com/pelias/pbf2json/pull/23

the gist of the changes is that we use the precomputed centroid passed in from the Go library where available to avoid doing those calcs in the nodejs process.

there is also some cleaning up and adding of tests to cover the centroid functionality

the result should be a faster and more stable build, plus we can potentially remove the one last piece of code in this repo which is not very well tested.