### PR TITLE
Use Address-deduplicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ You can optionally change:
   county, etc. names), but you can optionally create it via the
   [`pelias/admin-lookup`](https://github.com/pelias/admin-lookup) module; just set this property to `true`.  Consult
   the `admin-lookup` README for setup documentation (namely just downloading the Quattroshapes dataset).
+- `import.openstreetmap.deduplicate` - this makes it possible to import multiple datasets containing the same addresses, without getting duplicates in the pelias database.
+  Please see [`pelias/address-deduplicator`](https://github.com/pelias/address-deduplicator) for more details.
 
 If your paths point to an SSD rather than a HDD then you will get a significant speed boost, although this is not required.
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 **/
 
 var elasticsearch = require('pelias-dbclient'),
+    addressDedupStream = require( 'pelias-address-deduplicator' );
     adminLookup = require('pelias-admin-lookup'),
     dbmapper = require('./stream/dbmapper'),
     peliasConfig = require( 'pelias-config' ).generate();
@@ -30,8 +31,13 @@ osm.import = function(opts){
     pipeline = pipeline.pipe( adminLookup.stream() );
   }
 
+  pipeline = pipeline.pipe( osm.address.extractor() );
+  
+  if( peliasConfig.imports.openstreetmap.deduplicate ){
+    pipeline = pipeline.pipe( addressDedupStream() );
+  }
+  
   pipeline
-    .pipe( osm.address.extractor() )
     .pipe( osm.category.mapper( osm.category.defaults ) )
     .pipe( dbmapper() )
     .pipe( elasticsearch() );

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "iso-639-3": "^0.2.0",
     "merge": "^1.2.0",
     "pbf2json": "^3.0.0",
+    "pelias-address-deduplicator": "^1.x.x",
     "pelias-admin-lookup": "^2.0.8",
     "pelias-config": "latest",
     "pelias-dbclient": "0.0.9",


### PR DESCRIPTION
Hi,

Currently there is no possibility of using the address-deduplicator on openstreetmap addresses, as you can do with openaddresses. This adds the possibility of using pelias/address-deduplicator in the input stream to filter out already-seen addresses.