### PR TITLE
Add helpful error message when adminLookup is misconfigured

### DIFF
--- a/stream/adminLookup.js
+++ b/stream/adminLookup.js
@@ -2,6 +2,13 @@ var through = require('through2');
 var peliasConfig = require( 'pelias-config' ).generate();
 var wofAdminLookup = require('pelias-wof-admin-lookup');
 
+
+function sendPassthroughStream() {
+  return through.obj(function (doc, enc, next) {
+    next(null, doc);
+  });
+}
+
 /**
  * Generate a stream object that will handle the adminLookup when enabled.
  * When disabled, generate a passthrough stream.
@@ -14,15 +21,27 @@ function createStream(config, adminLookup) {
   config = config || peliasConfig;
   adminLookup = adminLookup || wofAdminLookup;
 
-  if (config.imports.openstreetmap.adminLookup) {
+  // disable adminLookup with empty config
+  if (!config.imports || !config.imports.openstreetmap) {
+    return sendPassthroughStream();
+  }
+
+  // admin lookup disabled
+  if (!config.imports.openstreetmap.adminLookup) {
+    return sendPassthroughStream();
+  }
+
+  // admin lookup enabled
+  if (config.imports.adminLookup && config.imports.adminLookup.url) {
     var pipResolver = adminLookup.createWofPipResolver(config.imports.adminLookup.url);
     return adminLookup.createLookupStream(pipResolver);
   }
-  else {
-    return through.obj(function (doc, enc, next) {
-      next(null, doc);
-    });
-  }
+
+  // throw error if flag is set but no URL configured
+  var message = 'Admin lookup is enabled but no url is specified in your config ' +
+    'at imports.adminLookup.url. Make sure a URL pointing to a Who\'s on First point ' +
+    'in polygon server (https://github.com/whosonfirst/go-whosonfirst-pip) is set in your config';
+  throw new Error(message);
 }
 
 module.exports = createStream;


### PR DESCRIPTION
Since [pelias/config](https://github.com/pelias/config) doesn't yet contain a default section for adminLookup (and there probably won't be a public Who's on First point in polygon server for a while), the default experience for setting up an importer is to get an error. See #93.

This PR tries to gracefully handle some different config combinations and, in the case where admin lookup is enabled for OSM but there's no point in polygon server URL set, print an error message that hopefully points users in the right direction. I'd really love suggestions for how to improve this error message even more.

Fixes #93 