### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Pelias OpenStreetMap importer
+
+This repository is part of the [Pelias](https://github.com/pelias/pelias)
+project. Pelias is an open-source, open-data geocoder built by
+[Mapzen](https://www.mapzen.com/) that also powers [Mapzen Search](https://mapzen.com/projects/search). Our
+official user documentation is [here](https://mapzen.com/documentation/search/).
+
+## Overview
 
 | ![osm](http://wiki.openstreetmap.org/w/images/archive/c/c8/20110430164439%21Public-images-osm_logo.png) | The openstreetmap importer provides a way of parsing, mapping and augmenting OSM data in to elasticsearch.         |
 | ------------- |:-------------|

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to use the importer you must first install and configure `elasticsearch
 
 You can follow the instructions here: https://github.com/pelias/pelias/blob/master/INSTALL.md to get set up.
 
-The recommended version for nodejs is `0.12+` and elasticsearch is `1.3.4+` although we also test against `nodejs@0.10`.
+The recommended version for nodejs is `0.12` and elasticsearch is `1.7`. We support Nodejs 4 and 5, but not Elasticsearch 2 (yet).
 
 Before continuing you should confirm that you have these tools correctly installed and elasticsearch is running on port `9200`.
 
@@ -159,6 +159,6 @@ $ npm run coverage
 
 ### Continuous Integration
 
-Travis tests every release against node version `0.10` & `0.12`.
+Travis tests every change against node version `0.10`, `0.12`, `4.x`, and `5.x`.
 
 [![Build Status](https://travis-ci.org/pelias/openstreetmap.png?branch=master)](https://travis-ci.org/pelias/openstreetmap)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ npm install
 $ node scripts/create_index.js
 ```
 
-In order to confirm that the mappings have been correctly inserted in to elasticsearch you can now query http://localhost:9200/pelias/_mapping
+In order to confirm that the mappings have been correctly inserted in to elasticsearch you can now query http://localhost:9200/pelias/\_mapping
 
 ## Running an import
 
@@ -97,8 +97,8 @@ $ PELIAS_CONFIG=<path_to_config_json> npm start
 ```
 
 You should now be able to retrieve the OSM data directly from `elasticsearch`:
-- http://localhost:9200/pelias/address/_search
-- http://localhost:9200/pelias/venue/_search
+- http://localhost:9200/pelias/address/\_search
+- http://localhost:9200/pelias/venue/\_search
 
 ## How long does it take?
 
@@ -113,7 +113,7 @@ If you are looking to run a planet-wide cluster like the one we provide at https
 Once you're all set up you can clone and install https://github.com/pelias/api which provides a RESTful webserver and the query logic required to control what information gets retrieved from the indeces and how it's formatted for the end user.
 
 To perform a very basic URI search you can execute a query such as:
-- http://localhost:9200/pelias/venue/_search?df=name.default&q=hackney%20city%20farm
+- http://localhost:9200/pelias/venue/\_search?df=name.default&q=hackney%20city%20farm
 
 ## More open data sets
 


### PR DESCRIPTION
There are more to come. The main thing here is removing most references to Quattroshapes, and adding a header that links to the Pelias meta-repo, Mapzen Search project page, and official docs.