### PR TITLE
Check the proper admin lookup config properties

### DIFF
--- a/stream/adminLookup.js
+++ b/stream/adminLookup.js
@@ -26,14 +26,8 @@ function createStream(config, adminLookup) {
     return sendPassthroughStream();
   }
 
-  // admin lookup disabled
-  if (!config.imports.openstreetmap.adminLookup) {
-    return sendPassthroughStream();
-  }
-
   // admin lookup enabled
-  if (config.imports.adminLookup) {
-    //var pipResolver = adminLookup.createWofPipResolver(config.imports.adminLookup.url);
+  if (config.imports.openstreetmap.adminLookup) {
     var pipResolver = adminLookup.createLocalWofPipResolver();
     return adminLookup.createLookupStream(pipResolver);
   } else {

--- a/test/stream/adminLookup.js
+++ b/test/stream/adminLookup.js
@@ -69,6 +69,38 @@ module.exports.tests.enabled = function(test, common) {
 
 };
 
+module.exports.tests.enabled_without_admin_lookup_config = function(test, common) {
+  var config = {
+    imports: {
+      openstreetmap: {
+        adminLookup: true
+      }
+    }
+  };
+
+  /*
+   * There was a bug (https://github.com/pelias/wof-admin-lookup/issues/51) where admin lookup could
+   * not be enabled without the adminLookup config section
+   */
+  test('enabled without any special adminLookup config: return pip stream', function (t) {
+    t.plan(1);
+
+    var streamMock = {madeBy: 'mock'};
+
+    var wofAdminLookup = {
+      createLocalWofPipResolver: function() {
+      },
+      createLookupStream: function() {
+        return streamMock;
+      }
+    };
+
+    var stream = adminLookup(config, wofAdminLookup);
+    t.equal(stream, streamMock, 'stream created');
+    t.end();
+  });
+};
+
 module.exports.tests.disabled = function (test, common) {
   var config = {
     imports: {


### PR DESCRIPTION
The admin lookup stream code was incorrectly checking the wrong
property, making it harder to enable admin lookup.

Thanks to @DylanFrese for helping us figure this out.

Related: pelias/wof-admin-lookup#52
Fixes pelias/wof-admin-lookup#51