### PR TITLE
Upgrade to pbf2json 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "iso-639-3": "^1.0.0",
     "lodash": "^4.0.0",
     "merge": "^1.2.0",
-    "pbf2json": "^4.0.0",
+    "pbf2json": "4.0.0",
     "pelias-address-deduplicator": "1.1.0",
     "pelias-config": "2.1.0",
     "pelias-dbclient": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "iso-639-3": "^1.0.0",
     "lodash": "^4.0.0",
     "merge": "^1.2.0",
-    "pbf2json": "4.0.0",
+    "pbf2json": "4.1.0",
     "pelias-address-deduplicator": "1.1.0",
     "pelias-config": "2.1.0",
     "pelias-dbclient": "2.0.0",


### PR DESCRIPTION
Also require an exact version of pbf2json rather than a caret range.

This is in line with https://github.com/pelias/pelias/issues/366, where
we decided to only use exact version deps for other Pelias code. This
both helps us track changes better, and ensure we can know exactly what
code we're releasing at any time.

Connects pelias/pelias#366
