### PR TITLE
Require Node.js 4.0 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - 0.12
   - 4
   - 6
 matrix:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Prerequisites
 
-* NodeJS `0.12` or newer (the latest in the Node 4 series is currently recommended)
+* NodeJS `4.0.0` or newer (the latest in the Node 4 series is currently recommended)
 * Elasticsearch 2.3+ (support for version 1.x has been deprecated).
 
 ## Clone and Install dependencies
@@ -119,4 +119,4 @@ $ npm run coverage
 
 ### Continuous Integration
 
-Travis tests every change against node version `0.12`, `4`, `5` and `6`.
+Travis tests every change against Node.js version `4` and `6`.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-semantic-release",
   "author": "mapzen",
   "description": "Pelias openstreetmap utilities",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "homepage": "https://github.com/mapzen/pelias-openstreetmap",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Wow this cascades quickly. Now that wof-admin-lookup requires Node 4, all the importers do too!

Connects pelias/pelias#404