### PR TITLE
Increase Node.js memory limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "end-to-end": "npm run pretest && node test/end-to-end.js;",
     "lint": "jshint .",
     "pretest": "test/pretest.sh",
-    "start": "node index.js",
+    "start": "node --max_old_space_size=4096 index.js",
     "test": "npm run units",
     "travis": "npm run check-dependencies && node ./test/travis-config.js && npm test && npm run end-to-end",
     "units": "node test/run.js | tap-spec",


### PR DESCRIPTION
The admin lookup worker processes are starting to hit the default memory
limit. Increasing it gives us time to improve the admin lookup
architecture.

Connected to https://github.com/pelias/wof-admin-lookup/issues/117