### PR TITLE
pbf2json: use replace_parser branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ esclient.log
 *.log
 nohup.out
 test/*.pbf
+test/*.pbf.idx
 coverage

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "joi": "^10.1.0",
     "lodash": "^4.16.0",
     "merge": "^1.2.0",
-    "pbf2json": "4.4.0",
+    "pbf2json": "git://github.com/pelias/pbf2json.git#replace_parser",
     "pelias-address-deduplicator": "1.1.0",
     "pelias-config": "2.11.0",
     "pelias-dbclient": "2.0.0",


### PR DESCRIPTION
[do not merge]

this is a testing branch for https://github.com/pelias/pbf2json/pull/46, no further changes are required, it can be used in a dev build as-is.

using the new https://github.com/missinglink/pbf parsing library, you can expect build times to be greatly reduced (end-to-end tests are 30% faster, in production this will likely be much more) and HDD usage for leveldb should be only 10% of what was previously required (~11GB for the planet).

note: the pbf lib has been tuned for an 8-16 core machine with ~16GB RAM, so it might need to have some variables tweaked to run optimally on other systems. expect a CPU utilization of ~500%-600%, it will likely not use all the available CPU all the time.

the fixtures file was updated to reflect greater floating point accuracy over the old parser, for example:

```diff
1001c1001
<         "lat": 49.25632
---
>         "lat": 49.256319
1399c1399
<         "lon": -123.138398,
---
>         "lon": -123.138397,
```