### PR TITLE
logging: change spy log level from info->verbose

### DIFF
--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -30,7 +30,7 @@ streams.import = function(){
     .pipe( streams.adminLookup() )
     .pipe( streams.deduper() )
     .pipe( spy.obj(function (doc) {
-        logger.info(doc.getGid(), doc.getName('default'), doc.getCentroid());
+        logger.verbose(doc.getGid(), doc.getName('default'), doc.getCentroid());
       })
     )
     .pipe( streams.dbMapper() )


### PR DESCRIPTION
the spy stream logs each new record, this PR simply changes the log level from info->verbose.

```bash
info: [openstreetmap-points] openstreetmap:address:node:342701864 5 Klitmøllervej lon=8.670321, lat=56.983651
info: [openstreetmap-points] openstreetmap:address:node:340582720 1 Bakkehegnet lon=12.391713, lat=55.757433
info: [openstreetmap-points] openstreetmap:address:node:340801972 20 Rønnebærkæret lon=12.278787, lat=55.585956
info: [openstreetmap-points] openstreetmap:address:node:341725570 87 Sankt Jørgens Vej lon=10.595304, lat=55.051658
info: [openstreetmap-points] openstreetmap:address:node:342488055 209 Skovvej lon=9.711022, lat=55.561912
info: [openstreetmap-points] openstreetmap:address:node:342701866 9 Klitmøllervej lon=8.667341, lat=56.985503
info: [openstreetmap-points] openstreetmap:address:node:340674218 153 Snebærhaven lon=12.367934, lat=55.676879
info: [openstreetmap-points] openstreetmap:address:node:340582721 3 Bakkehegnet lon=12.391299, lat=55.757441

... etc for every record imported from OSM
```

this now matches the behavior of the deduplication logs:

```bash
verbose: [openstreetmap] [address_extractor] duplicating a venue with address
verbose: [openstreetmap] [address_extractor] duplicating a venue with address
verbose: [openstreetmap] [address_extractor] duplicating a venue with address
verbose: [openstreetmap] [address_extractor] duplicating a venue with address
verbose: [openstreetmap] [address_extractor] duplicating a venue with address
verbose: [openstreetmap] [address_extractor] duplicating a venue with address
```