### PR TITLE
performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ esclient.log
 *.log
 nohup.out
 test/*.pbf
+test/*.pbf.idx
 coverage

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pelias-config": "2.11.0",
     "pelias-dbclient": "2.0.0",
     "pelias-logger": "0.2.0",
-    "pelias-model": "4.9.0",
+    "pelias-model": "4.10.0",
     "pelias-wof-admin-lookup": "3.7.1",
     "through2": "^2.0.0",
     "through2-sink": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pelias-config": "2.11.0",
     "pelias-dbclient": "2.0.0",
     "pelias-logger": "0.2.0",
-    "pelias-model": "4.8.1",
+    "pelias-model": "4.9.0",
     "pelias-wof-admin-lookup": "3.7.1",
     "through2": "^2.0.0",
     "through2-sink": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "joi": "^10.1.0",
     "lodash": "^4.16.0",
     "merge": "^1.2.0",
-    "pbf2json": "4.4.0",
+    "pbf2json": "git://github.com/pelias/pbf2json.git#replace_parser",
     "pelias-address-deduplicator": "1.1.0",
     "pelias-config": "2.11.0",
     "pelias-dbclient": "2.0.0",

--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -111,16 +111,10 @@ module.exports = function(){
   return stream;
 };
 
-// properties to map from the osm record to the pelias doc
-var addrProps = [ 'name', 'number', 'street', 'zip' ];
-
 // call document setters and ignore non-fatal errors
 function setProperties( record, doc ){
-  addrProps.forEach( function ( prop ){
-    try {
-      record.setAddress( prop, doc.getAddress( prop ) );
-    } catch ( ex ) {}
-  });
+  record.address_parts = doc.address_parts;
+  record.parent = doc.parent;
 }
 
 // export for testing

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -7,7 +7,6 @@
 var through = require('through2');
 var Document = require('pelias-model').Document;
 var peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
-var _ = require('lodash');
 
 module.exports = function(){
 
@@ -38,11 +37,6 @@ module.exports = function(){
             lon: item.centroid.lon
           });
         }
-      }
-
-      // Set noderefs (for ways)
-      if( item.hasOwnProperty('nodes') ){
-        doc.setMeta( 'nodes', item.nodes );
       }
 
       // Store osm tags as a property inside _meta

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -24,10 +24,9 @@ streams.import = function(){
   streams.pbfParser()
     .pipe( streams.docConstructor() )
     .pipe( streams.tagMapper() )
-    .pipe( streams.docDenormalizer() )
-    .pipe( streams.addressExtractor() )
     .pipe( streams.categoryMapper( categoryDefaults ) )
     .pipe( streams.adminLookup() )
+    .pipe( streams.addressExtractor() )
     .pipe( streams.deduper() )
     .pipe( spy.obj(function (doc) {
         logger.info(doc.getGid(), doc.getName('default'), doc.getCentroid());

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -49,16 +49,15 @@ var results = [];
 streams.pbfParser()
   .pipe( streams.docConstructor() )
   .pipe( streams.tagMapper() )
-  .pipe( streams.docDenormalizer() )
-  .pipe( streams.addressExtractor() )
   .pipe( streams.categoryMapper( streams.config.categoryDefaults ) )
+  .pipe( streams.addressExtractor() )
   .pipe( model.createDocumentMapperStream() )
   .pipe( sink.obj(function (doc) {
     results.push(doc);
   }) )
   .on('error', function error(err) {
     console.error('YIKES! Test failed with the following error: ', err.message);
-    process.exit();
+    process.exit(1);
   })
   .on('finish', function assert(){
 

--- a/test/stream/document_constructor.js
+++ b/test/stream/document_constructor.js
@@ -98,28 +98,6 @@ module.exports.tests.centroid = function(test, common) {
   });
 };
 
-module.exports.tests.noderefs = function(test, common) {
-  var nodeData = [ 'X', 'Y' ];
-  test('noderefs: valid', function(t) {
-    var stream = constructor();
-    stream.pipe( through.obj( function( doc, enc, next ){
-      t.equal( doc.getMeta('nodes'), nodeData, 'noderefs set' );
-      t.end(); // test will fail if not called (or called twice).
-      next();
-    }));
-    stream.write({ id: 1, type: 'X', nodes: nodeData });
-  });
-  test('noderefs: invalid', function(t) {
-    var stream = constructor();
-    stream.pipe( through.obj( function( doc, enc, next ){
-      t.false( doc.getMeta('nodes'), 'no noderefs' );
-      t.end(); // test will fail if not called (or called twice).
-      next();
-    }));
-    stream.write({ id: 1, type: 'X' });
-  });
-};
-
 module.exports.tests.tags = function(test, common) {
   var tagData = [ 'X', 'Y' ];
   test('noderefs: valid', function(t) {


### PR DESCRIPTION
note: branched off `replace_parser`, please merge https://github.com/pelias/openstreetmap/pull/291 first.

this PR includes some performance improvements:

- update `pelias/pbf2json` to latest version.
- update `pelias/model` to latest version.
- remove references to `docDenormalizer` and `nodes` which are no longer required/supported
- move `addressExtractor` stream after `adminLookup` so that duplicate lat/lons are not looked up twice.

note: package modules `pbf2json` and `pelias-model` should be pegged to the latest version after all open PRs are merged on those repos & their `npm module` has been published.