### PR TITLE
Put verbose point logging behind a config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ See [the config](https://github.com/pelias/config) documentation for details on 
 - `imports.openstreetmap.download[0].sourceURL` - this is the source URL of the pbf file to be downloaded
 - `imports.openstreetmap.import[0].filename` - this is the name of the pbf file you downloaded
 - `imports.openstreetmap.leveldbpath` - this is the directory where temporary files will be stored in order to denormalize osm ways, in the case of a planet import it is best to have 100GB free so you don't run out of disk.
+- `imports.openstreetmap.logDocumentCentroids` - Set to true to log (to the verbose logger level) all document centroids. This output can be useful for generating statistics about the OSM import, but will also inflate the log size considerably. A log of all centroids for a full OSM build is over 10GB
 
 > __PRO-TIP:__ If your paths point to an SSD rather than a HDD then you will get a significant speed boost, although this is not required.
 

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -1,6 +1,7 @@
 var spy = require('through2-spy');
 var logger = require('pelias-logger').get('openstreetmap-points');
 var categoryDefaults = require('../config/category_map');
+var peliasConfig = require( 'pelias-config' ).generate();
 
 var streams = {};
 
@@ -30,9 +31,10 @@ streams.import = function(){
     .pipe( streams.adminLookup() )
     .pipe( streams.deduper() )
     .pipe( spy.obj(function (doc) {
+      if (peliasConfig.imports.openstreetmap.logDocumentCentroids) {
         logger.verbose(doc.getGid(), doc.getName('default'), doc.getCentroid());
-      })
-    )
+      }
+    }))
     .pipe( streams.dbMapper() )
     .pipe( streams.elasticsearch() );
 };


### PR DESCRIPTION
This importer currently logs _every_ record imported as well as its name and centroid. While useful for debugging, it's not needed all the time, even at the `verbose` logger level.

By putting this option behind a `pelias.json` config flag (defaulting to off) we can have it when we need it, and save over 10GB in each of our build logs when we don't.