### PR TITLE
Remove very noisy centroid logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "pelias-wof-admin-lookup": "4.1.0",
     "through2": "^2.0.0",
     "through2-sink": "^1.0.0",
-    "through2-spy": "^2.0.0",
     "trimmer": "^2.0.0"
   },
   "devDependencies": {

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -1,4 +1,3 @@
-var spy = require('through2-spy');
 var logger = require('pelias-logger').get('openstreetmap-points');
 var categoryDefaults = require('../config/category_map');
 
@@ -29,10 +28,6 @@ streams.import = function(){
     .pipe( streams.categoryMapper( categoryDefaults ) )
     .pipe( streams.adminLookup() )
     .pipe( streams.deduper() )
-    .pipe( spy.obj(function (doc) {
-        logger.verbose(doc.getGid(), doc.getName('default'), doc.getCentroid());
-      })
-    )
     .pipe( streams.dbMapper() )
     .pipe( streams.elasticsearch() );
 };


### PR DESCRIPTION
This log will generate over 10GB of output on _every_ full planet build.
It was useful for analyzing builds, but that sort of analysis could also
easily be done as a separate task that would complete much faster than a
build.

Replaces https://github.com/pelias/openstreetmap/pull/339