### PR TITLE
Default to HTTPS for planet file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ $ npm install
 
 ## Download data
 
-The importer will accept any valid `pbf` extract you have, this can be a full planet file (25GB+) from http://planet.openstreetmap.org/ or a smaller extract from https://mapzen.com/metro-extracts/ or http://download.geofabrik.de/
+The importer will accept any valid `pbf` extract you have, such as a full planet file (39GB+) from [planet.openstreetmap.org](https://planet.openstreetmap.org) or [download.geofabrik.de](https://download.geofabrik.de)
 You can use the included download script to obtain the desired `pbf` files as follows. In the configuration file you can
 specify which files are to be downloaded. They will all be downloaded to the `imports.openstreetmap.datapath` directory.
-If no download sources are specified in the configuration, the entire planet file will be downloaded from the
-[OpenStreetMap download site](http://planet.openstreetmap.org/pbf/planet-latest.osm.pbf).
+
+If no download sources are specified in the configuration, the entire planet file will be downloaded. Keep in mind this file is quite large.
 
 ```bash
 $ PELIAS_CONFIG=<path-to-config> npm run download

--- a/util/download_data.js
+++ b/util/download_data.js
@@ -23,7 +23,7 @@ function download(callback) {
   // if no download sources are specified, default to the planet file
   if (_.isEmpty(config.imports.openstreetmap.download)) {
     sources = [
-      'http://planet.openstreetmap.org/pbf/planet-latest.osm.pbf'
+      'https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf'
     ];
   }
   else {


### PR DESCRIPTION
We have curl configured to redirect, but this will ensure HTTPS is the default, which is definitely a good thing.

Fixes #396 