### PR TITLE
Remove 'Invalid doc not pushed downstream' error

### DIFF
--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -97,9 +97,6 @@ module.exports = function(){
     if ( isAddress && isNamedPoi ) {
       peliasLogger.verbose('[address_extractor] duplicating a venue with address');
     }
-    else if ( !isAddress && !isNamedPoi ) {
-      peliasLogger.error('[address_extractor] Invalid doc not pushed downstream: ', JSON.stringify( doc, null, 2 ));
-    }
 
     return next();
 


### PR DESCRIPTION
This is not really an error, as it's the expected behavior when there is not enough data in a venue record to also create an address record.

The resulting output is both extremely verbose and potentially confusing to users.