### PR TITLE
support for mapping tags to name.default aliases

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,6 +17,6 @@
   "undef": true,
   "unused": false,
   "maxparams": 4,
-  "maxdepth": 4,
+  "maxdepth": 5,
   "maxlen": 140
 }

--- a/schema/name_osm.js
+++ b/schema/name_osm.js
@@ -7,21 +7,43 @@
 
   eg. tags['alt_name'] -> doc.name['alternative']
 
+  The value 'default' is special, it defines the name used by default
+  for elasticsearch queries, it has the unique ability to specify multiple
+  keys with a value of 'default'.
+
+  When multiple keys have the value 'default' then they are considered
+  as aliases of the default field.
+
+  The '_primary' property defined below defines which of those aliases
+  is considered the 'primary default name' for label generation.
+
+  No values other than 'default' should be specified more than once.
+
   @ref: http://wiki.openstreetmap.org/wiki/Key:name
   @ref: http://wiki.openstreetmap.org/wiki/Names
 **/
 
 var OSM_NAMING_SCHEMA = {
   'name':             'default',
-  'loc_name':         'local',
-  'alt_name':         'alternative',
+  'loc_name':         'default',
+  'alt_name':         'default',
   'int_name':         'international',
   'nat_name':         'national',
   'official_name':    'official',
   'old_name':         'old',
   'reg_name':         'regional',
-  'short_name':       'short',
+  'short_name':       'default',
   'sorting_name':     'sorting'
 };
+
+// this property is considered the 'primary name'
+// for label generation, the others are considered
+// secondary or 'aliases'.
+Object.defineProperty(OSM_NAMING_SCHEMA, '_primary', {
+  value: 'name',
+  enumerable: false,
+  configurable: false,
+  writable: false
+});
 
 module.exports = OSM_NAMING_SCHEMA;

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -48,7 +48,13 @@ module.exports = function(){
         else if( tag in NAME_SCHEMA ){
           var val2 = trim( tags[tag] );
           if( val2 ){
-            doc.setName( NAME_SCHEMA[tag], val2 );
+            if( tag === NAME_SCHEMA._primary ){
+              doc.setName( NAME_SCHEMA[tag], val2 );
+            } else if ( 'default' === NAME_SCHEMA[tag] ) {
+              doc.setNameAlias( NAME_SCHEMA[tag], val2 );
+            } else {
+              doc.setName( NAME_SCHEMA[tag], val2 );
+            }
           }
         }
 

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -67,11 +67,40 @@ module.exports.tests.osm_names = function(test, common) {
   });
   test('maps - name schema', function(t) {
     var doc = new Document('a','b',1);
-    doc.setMeta('tags', { loc_name: 'test1', nat_name: 'test2' });
+    doc.setMeta('tags', { int_name: 'test1', nat_name: 'test2' });
     var stream = mapper();
     stream.pipe( through.obj( function( doc, enc, next ){
-      t.equal(doc.getName('local'), 'test1', 'correctly mapped');
+      t.equal(doc.getName('international'), 'test1', 'correctly mapped');
       t.equal(doc.getName('national'), 'test2', 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+  test('maps - name aliases', function(t) {
+    var doc = new Document('a','b',1);
+    doc.setMeta('tags', {
+      loc_name: 'loc_name',
+      nat_name: 'nat_name',
+      int_name: 'int_name',
+      name: 'name',
+      alt_name: 'alt_name',
+      official_name: 'official_name',
+      old_name: 'old_name',
+      reg_name: 'reg_name',
+      short_name: 'short_name',
+      sorting_name: 'sorting_name'
+    });
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal(doc.getName('default'), 'name', 'correctly mapped');
+      t.deepEqual(doc.getNameAliases('default'), ['loc_name','alt_name','short_name'], 'correctly mapped');
+      t.equal(doc.getName('national'), 'nat_name', 'correctly mapped');
+      t.equal(doc.getName('international'), 'int_name', 'correctly mapped');
+      t.equal(doc.getName('official'), 'official_name', 'correctly mapped');
+      t.equal(doc.getName('old'), 'old_name', 'correctly mapped');
+      t.equal(doc.getName('regional'), 'reg_name', 'correctly mapped');
+      t.equal(doc.getName('sorting'), 'sorting_name', 'correctly mapped');
       t.end(); // test will fail if not called (or called twice).
       next();
     }));


### PR DESCRIPTION
this PR allows OSM tags to be mapped as aliases of the `name.default` field.

the `schema/name_osm.js` file contains a mapping of OSM tags to `name.*` fields.

prior to this PR we were only able to map 1:1 from OSM to the Pelias model.

this PR now supports multiple values in that object set as `default`, in this case the additional tags will be mapped as aliases of the `name.default` field.

the configuration also adds an additional inenumerable property called `_primary` which defines which of those is considered the 'primary' name.

an example tag mapping:

```
osm_tags = { name: "foo", short_name: "bar", reg_name: "baz" }

# prior to the PR
name = {
  default: "foo",
  short: "bar",
  regional: "baz"
}

# after the PR
name = {
  default: [ "foo", "bar" ],
  regional: "baz"
}
```

---

I enabled 3 tags as aliases of default: `[ short_name, alt_name, loc_name ]`, of these only `short_name` is supported by nominatim.

https://wiki.openstreetmap.org/wiki/Names#Key_Variations

The [test/fixtures/combined_vancouver_queens.json](https://github.com/pelias/openstreetmap/pull/435/files#diff-8dc60323dfa03395125c0936781cf634) file in this PR includes a diff which shows and example of the expected changes.