### PR TITLE
feat(test): Use test script to catch errors

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -o pipefail
+
+NODE_ENV=test node test/run.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "lint": "jshint .",
     "pretest": "test/pretest.sh",
     "start": "node --max_old_space_size=4096 index.js",
-    "test": "NODE_ENV=test npm run units",
+    "test": "npm run units",
     "travis": "node ./test/travis-config.js && npm test && npm run end-to-end",
-    "units": "node test/run.js | tap-spec",
+    "units": "./bin/test",
     "validate": "npm ls"
   },
   "repository": {


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in the unit test run, even though they return non-zero status codes. By using a dedicated script to run the tests, with the `pipefail` option,
we can catch them.

Connects https://github.com/pelias/pelias/issues/744