### PR TITLE
fix(docker): remove default Docker command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,3 @@ USER pelias
 
 # run tests
 RUN npm test
-
-CMD [ "./bin/start" ]


### PR DESCRIPTION
This was added in https://github.com/pelias/openstreetmap/pull/454 and while it may be nice to have importer containers know how to start themselves, it means that running `pelias compose up` (or
`docker-compose up`) in the pelias/docker repo would _always_ start all the importers.

With that in mind, it's best to leave this off for now, and have the `pelias` executable know to call `./bin/start` on each importer.