### PR TITLE
feat(download): clarify importer name when downloading

### DIFF
--- a/util/download_data.js
+++ b/util/download_data.js
@@ -5,7 +5,7 @@ const async = require('async');
 const child_process = require('child_process');
 const fs = require('fs-extra');
 const config = require( 'pelias-config' ).generate(require('../schema'));
-const logger = require('pelias-logger').get('download');
+const logger = require('pelias-logger').get('openstreetmap-download');
 
 if (require.main === module) {
   download((err) => {


### PR DESCRIPTION
Similar to https://github.com/pelias/whosonfirst/pull/397, since `pelias/docker` often runs multiple downloads in parallel, it's nice if this downloader is explicit that it's downloading data for OpenStreetMap.