### PR TITLE
fix(docker): Clean up files left from running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN npm install
 # add local code
 ADD . ${WORKDIR}
 
-# run as the pelias user, starting with tests
-USER pelias
+# run tests, clean up LevelDB lockfile
+RUN npm test && rm -rf /tmp/*
 
-# run tests
-RUN npm test
+# run as the pelias user
+USER pelias


### PR DESCRIPTION
When running the end-to-end tests, LevelDB (via `pbf2json`) leaves behind its data in /tmp, and does not clean itself up.

Future containers run using this image will almost certainly also run `pbf2json`, and may not run using the same user id, meaning permissions to overwrite the files in `/tmp` may not exist. Thus, it's best if they
are removed in the Docker image.

Connects https://github.com/pelias/pelias/issues/745
Connects https://github.com/pelias/docker/pull/20