### PR TITLE
feat(logger): Use dbclient name functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pbf2json": "^5.0.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^3.3.0",
-    "pelias-dbclient": "^2.5.6",
+    "pelias-dbclient": "^2.8.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^5.7.1",
     "pelias-wof-admin-lookup": "^5.0.0",

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -26,7 +26,7 @@ streams.import = function(){
     .pipe( streams.categoryMapper( categoryDefaults ) )
     .pipe( streams.adminLookup() )
     .pipe( streams.dbMapper() )
-    .pipe( streams.elasticsearch() );
+    .pipe( streams.elasticsearch({name: 'openstreetmap'}) );
 };
 
 module.exports = streams;


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which
importer during an import.

Connects https://github.com/pelias/dbclient/issues/101