### PR TITLE
Add "Railway Station alias" to improve searches

### DIFF
--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -78,6 +78,15 @@ module.exports = function(){
           }
         }
       }
+
+      // Add alias for 'Railway Station' as this is often not part of the name
+      if( tags.hasOwnProperty('railway') ){
+      {
+        if( tags.railway == 'station' ){
+          doc.setNameAlias( 'default', doc.getName() + " Railway Station" );
+          doc.setPopularity(1000);
+        }
+      }
     }
 
     catch( e ){


### PR DESCRIPTION
Many railway stations just have the station name without any mention of "railway" or "station" in it.
E.g. https://www.openstreetmap.org/node/1886265358
In that case the station name is the same as a locality so it's virtually impossible to find the station in search results.

This patch will add "Railway Station" as an alias to allow for easier searching.
It also adds a small popularity boost to the station since they are common landmarks.

TODO: Likely this needs to be expanded for bus stations, light rail, ferry, etc...