### PR TITLE
feat(ids): Change ID section separator to forward slash

### DIFF
--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -17,7 +17,7 @@ module.exports = function(){
       if (!item.type || ! item.id) {
         throw new Error('doc without valid id or type');
       }
-      var uniqueId = [ item.type, item.id ].join(':');
+      var uniqueId = [ item.type, item.id ].join('/');
 
       // we need to assume it will be a venue and later if it turns out to be an address it will get changed
       var doc = new Document( 'openstreetmap', 'venue', uniqueId );

--- a/test/stream/document_constructor.js
+++ b/test/stream/document_constructor.js
@@ -25,7 +25,7 @@ module.exports.tests.instantiate = function(test, common) {
     var stream = constructor();
     stream.pipe( through.obj( function( doc, enc, next ){
       t.equal( Object.getPrototypeOf(doc), Document.prototype, 'correct proto' );
-      t.equal( doc.getId(), 'X:1', 'correct id' );
+      t.equal( doc.getId(), 'X/1', 'correct id' );
       t.equal( doc.getType(), 'venue', 'defaults to venue' );
       t.end(); // test will fail if not called (or called twice).
       next();


### PR DESCRIPTION
BREAKING CHANGE

OpenStreetMap effectively has an ID structure composed of two parts: a record type specifier (node, way, relation) and a numeric identifier. Both are needed because there is often overlap between the numeric identifiers of different types.

For a long time, Pelias has used the OSM record type and numeric identifier to construct Pelias GIDs. The character chosen to separate the OSM type and ID was `:`, which is the same as the separator between parts of a Pelias GID.

This lead to two relatively minor problems:

1. It causes confusion as to the structure of Pelias GIDs. The official format is `source:layer:id`, but when the `id` itself also has a colon in it, there's the potential for confusion both for people attempting to
understand the structure, and for code attempting to correctly parse the GIDs.

2. It does not allow directly copying and pasting of the OSM ID into any OSM tool to view that record. For example, a `node` with id `123` can be viewed directly on the OSM website at https://openstreetmap.org/node/123.

This PR changes the OSM ID section separator to a forward slash (`/`), solving both the above problems.

This _is_ a breaking change for anyone using OSM GIDs as part of the Pelias blacklist functionality. A good workaround is to make a copy of all blacklisted OSM IDS, so that there is one with the old separator, and one with the new separator. This ensures a seamless transition.