### PR TITLE
add selected tags to addendum

### DIFF
--- a/stream/addendum_mapper.js
+++ b/stream/addendum_mapper.js
@@ -1,0 +1,64 @@
+/**
+  The addendum mapper is responsible for adding interesting metadata
+  as an 'addendum' to the record.
+
+  @see: https://github.com/pelias/api/pull/1255
+**/
+
+const through = require('through2');
+const peliasLogger = require('pelias-logger').get('openstreetmap');
+const whitelist = [
+  'wheelchair', // Wheelchair accessibility
+  'iata', // IATA airport codes
+  'icao', // ICAO airport codes
+  'wikidata', // Wikidata concordance
+  'wikipedia', // Wikipedia concordance
+  // 'website', // Website URL
+  // 'phone', // Telephone number
+  // 'opening_hours', // Opening hours
+];
+
+module.exports = function(){
+
+  return through.obj(( doc, enc, next ) => {
+
+    try {
+
+      // skip records with no tags
+      let tags = doc.getMeta('tags');
+      if( !tags ){
+        return next( null, doc );
+      }
+
+      let addendum = {};
+
+      // iterate over mapping
+      whitelist.forEach(key => {
+
+        // check each whitelist key against document tags
+        if( !tags.hasOwnProperty( key ) ){ return; }
+
+        // set addendum key
+        let value = tags[key].trim();
+        if( !!value.length ){
+          addendum[ key ] = value;
+        }
+      });
+
+      // set document addendum
+      if( !!Object.keys( addendum ).length ){
+        doc.setAddendum( 'osm', addendum );
+      }
+    }
+
+    catch( e ){
+      peliasLogger.error( 'addendum_mapper error' );
+      peliasLogger.error( e.stack );
+      peliasLogger.error( JSON.stringify( doc, null, 2 ) );
+    }
+
+    return next( null, doc );
+
+  });
+
+};

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -13,6 +13,7 @@ streams.tagMapper = require('./tag_mapper');
 streams.adminLookup = require('pelias-wof-admin-lookup').create;
 streams.addressExtractor = require('./address_extractor');
 streams.categoryMapper = require('./category_mapper');
+streams.addendumMapper = require('./addendum_mapper');
 streams.dbMapper = require('pelias-model').createDocumentMapperStream;
 streams.elasticsearch = require('pelias-dbclient');
 
@@ -24,6 +25,7 @@ streams.import = function(){
     .pipe( streams.addressExtractor() )
     .pipe( streams.blacklistStream() )
     .pipe( streams.categoryMapper( categoryDefaults ) )
+    .pipe( streams.addendumMapper() )
     .pipe( streams.adminLookup() )
     .pipe( streams.dbMapper() )
     .pipe( streams.elasticsearch({name: 'openstreetmap'}) );

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -51,6 +51,7 @@ streams.pbfParser()
   .pipe( streams.tagMapper() )
   .pipe( streams.addressExtractor() )
   .pipe( streams.categoryMapper( streams.config.categoryDefaults ) )
+  .pipe( streams.addendumMapper() )
   .pipe( model.createDocumentMapperStream() )
   .pipe( sink.obj(function (doc) {
     results.push(doc);

--- a/test/run.js
+++ b/test/run.js
@@ -10,6 +10,7 @@ var tests = [
   require('./config/localized_name_keys'),
   require('./stream/address_extractor'),
   require('./stream/category_mapper'),
+  require('./stream/addendum_mapper'),
   require('./stream/document_constructor'),
   require('./stream/importPipeline'),
   require('./stream/pbf'),

--- a/test/stream/addendum_mapper.js
+++ b/test/stream/addendum_mapper.js
@@ -1,0 +1,166 @@
+const through = require('through2');
+const mapper = require('../../stream/addendum_mapper');
+const ixtures = require('../fixtures/docs');
+const Document = require('pelias-model').Document;
+
+module.exports.tests = {};
+
+// test exports
+module.exports.tests.interface = function (test, common) {
+  test('interface: factory', t => {
+    t.equal(typeof mapper, 'function', 'stream factory');
+    t.end();
+  });
+  test('interface: stream', t => {
+    var stream = mapper();
+    t.equal(typeof stream, 'object', 'valid stream');
+    t.equal(typeof stream._read, 'function', 'valid readable');
+    t.equal(typeof stream._write, 'function', 'valid writeable');
+    t.end();
+  });
+};
+
+// ===================== default mapping ======================
+
+module.exports.tests.wheelchair = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'wheelchair': 'true' });
+  test('maps - wheelchair', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { wheelchair: 'true' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.iata = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'iata': 'PEG' });
+  test('maps - iata', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { iata: 'PEG' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.icao = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'icao': 'LIRZ' });
+  test('maps - icao', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { icao: 'LIRZ' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.wikidata = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'wikidata': 'Q1371018' });
+  test('maps - wikidata', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { wikidata: 'Q1371018' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.wikipedia = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'wikipedia': 'it:Aeroporto di Perugia' });
+  test('maps - wikipedia', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { wikipedia: 'it:Aeroporto di Perugia' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ======================= errors ========================
+
+// catch general errors in the stream, emit logs and passthrough the doc
+module.exports.tests.catch_thrown_errors = function (test, common) {
+  test('errors - catch thrown errors', t => {
+    var doc = new Document('osm', 'a', 1);
+
+    // this method will throw a generic Error for testing
+    doc.getMeta = function () { throw new Error('test'); };
+
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getType(), 'a', 'doc passthrough');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.empty_tag_value = function (test, common) {
+  test('errors - ignore empty tags', t => {
+    var doc = new Document('osm', 'a', 1);
+    doc.setMeta('tags', { 'wheelchair': '' });
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.false(doc.addendum.osm, 'ignore empty tags');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.tab_only_value = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'wheelchair': '\t' });
+  test('errors - tab only value', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.false(doc.addendum.osm, 'remove tabs');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.newline_only_value = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'wheelchair': '\n' });
+  test('errors - newline only value', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.false(doc.addendum.osm, 'remove newlines');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('addendum_mapper: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/stream/importPipeline.js
+++ b/test/stream/importPipeline.js
@@ -15,6 +15,7 @@ module.exports.tests.interface = function(test, common) {
     'adminLookup',
     'addressExtractor',
     'categoryMapper',
+    'addendumMapper',
     'dbMapper',
     'elasticsearch',
     'import'


### PR DESCRIPTION
This is a feature I've been wanting for some time.
This PR adds some selected OSM tags to the addendum for each record.

For now, the whitelist is:
```
const whitelist = [
  'wheelchair', // Wheelchair accessibility
  'iata', // IATA airport codes
  'icao', // ICAO airport codes
  'wikidata', // Wikidata concordance
  'wikipedia', // Wikipedia concordance
  // 'website', // Website URL
  // 'phone', // Telephone number
  // 'opening_hours', // Opening hours
];
```

I commented out the contact details and opening hours, for now, let's see how much disk space these smaller fields consume before we uncomment the other ones.

also open to import some other fields but let's not go crazy and import all of OSM, only concordances and tags directly related to geocoding will be accepted.

example: https://www.openstreetmap.org/way/60437625

see the diff: https://github.com/pelias/openstreetmap/pull/487/files#diff-8dc60323dfa03395125c0936781cf634

cc/ @Joxit thoughts?