### PR TITLE
do not set name field for addresses

### DIFF
--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -18,7 +18,7 @@
   duplicating the data across to the new doc instance while adjusting it's id and type.
 
   In a rare case it is possible that the record contains neither a valid name nor a valid
-  address. If this case in encountered then the parser should be modified so these records
+  address. If this case is encountered then the parser should be modified so these records
   are no longer passed down the pipeline; as they will simply be discarded because they are
   not searchable.
 **/

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -11,7 +11,7 @@ streams.docConstructor = require('./document_constructor');
 streams.blacklistStream = require('pelias-blacklist-stream');
 streams.tagMapper = require('./tag_mapper');
 streams.adminLookup = require('pelias-wof-admin-lookup').create;
-streams.addressExtractor = require('./address_extractor');
+// streams.addressExtractor = require('./address_extractor');
 streams.categoryMapper = require('./category_mapper');
 streams.dbMapper = require('pelias-model').createDocumentMapperStream;
 streams.elasticsearch = require('pelias-dbclient');
@@ -21,7 +21,7 @@ streams.import = function(){
   streams.pbfParser()
     .pipe( streams.docConstructor() )
     .pipe( streams.tagMapper() )
-    .pipe( streams.addressExtractor() )
+    // .pipe( streams.addressExtractor() )
     .pipe( streams.blacklistStream() )
     .pipe( streams.categoryMapper( categoryDefaults ) )
     .pipe( streams.adminLookup() )

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -49,7 +49,7 @@ var results = [];
 streams.pbfParser()
   .pipe( streams.docConstructor() )
   .pipe( streams.tagMapper() )
-  .pipe( streams.addressExtractor() )
+  // .pipe( streams.addressExtractor() )
   .pipe( streams.categoryMapper( streams.config.categoryDefaults ) )
   .pipe( model.createDocumentMapperStream() )
   .pipe( sink.obj(function (doc) {

--- a/test/stream/importPipeline.js
+++ b/test/stream/importPipeline.js
@@ -13,7 +13,7 @@ module.exports.tests.interface = function(test, common) {
     'blacklistStream',
     'tagMapper',
     'adminLookup',
-    'addressExtractor',
+    // 'addressExtractor',
     'categoryMapper',
     'dbMapper',
     'elasticsearch',


### PR DESCRIPTION
DRAFT WIP

This PR makes use of https://github.com/pelias/schema/pull/364 to remove the duplication of data between the `address_parts` fields and the `name.default` field.

Removing the `address_extractor` stream means that no `address` layer records will be produced.
Prior to this PR we would clone `venue` records to the `address` layer, and, in fact, we would also had support for `accept semi-colon delimited house numbers`.

So this PR is still WIP, we'd need to give some more consideration to the impact of the above changes before we could merge this.

Related https://github.com/pelias/openaddresses/pull/424