### PR TITLE
feat(features): Add pedestrian squares

### DIFF
--- a/config/features.js
+++ b/config/features.js
@@ -22,6 +22,8 @@ var venue_tags = [
   'railway~halt+name',
   'railway~subway_entrance+name',
   'railway~train_station_entrance+name',
+  'highway~pedestrian+area~yes+name',
+  'place~square+name',
   'sport+name',
   'natural+name',
   'tourism+name',


### PR DESCRIPTION
Pedestrian squares are often well known places that are essentially venues. This change allows any OSM record with the tags `highway=pedestrian`, `area=yes`, and a name to be imported as a venue.