### PR TITLE
venue popularity

### DIFF
--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -14,6 +14,7 @@ streams.adminLookup = require('pelias-wof-admin-lookup').create;
 streams.addressExtractor = require('./address_extractor');
 streams.categoryMapper = require('./category_mapper');
 streams.addendumMapper = require('./addendum_mapper');
+streams.popularityMapper = require('./popularity_mapper');
 streams.dbMapper = require('pelias-model').createDocumentMapperStream;
 streams.elasticsearch = require('pelias-dbclient');
 
@@ -26,6 +27,7 @@ streams.import = function(){
     .pipe( streams.blacklistStream() )
     .pipe( streams.categoryMapper( categoryDefaults ) )
     .pipe( streams.addendumMapper() )
+    .pipe( streams.popularityMapper() )
     .pipe( streams.adminLookup() )
     .pipe( streams.dbMapper() )
     .pipe( streams.elasticsearch({name: 'openstreetmap'}) );

--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -1,0 +1,199 @@
+/**
+  The popularity mapper is responsible for generating a 'popularity'
+  value by inspecting OSM tags.
+
+  Disused and abandoned places are given a strong negative score.
+  If the popularity score is less than zero then the document is discarded.
+
+  Feel free to make changes to this mapping file!
+**/
+
+const through = require('through2');
+const peliasLogger = require('pelias-logger').get('openstreetmap');
+
+const config = {
+  // https://taginfo.openstreetmap.org/keys/importance
+  importance: {
+    international: { _score: 50000 },
+    national: { _score: 10000 },
+    regional: { _score: 5000 },
+    urban: { _score: 1000 },
+    suburban: { _score: 500 },
+    local: { _score: 100 },
+  },
+
+  // concordances
+  wikipedia: { _score: 3000 },
+  wikidata: { _score: 3000 },
+
+  // properties found on major landmarks &
+  // public buildings.
+  architect: { _score: 5000 },
+  heritage: { _score: 5000 },
+  'heritage:operator': { _score: 2000 },
+  historic: {
+    building: { _score: 5000 },
+    church: { _score: 5000 },
+    _score: 1000,
+  },
+  building: {
+    colour: { _score: 2000 },
+    material: { _score: 2000 },
+    supermarket: { _score: 2000 },
+    civic: { _score: 2000 },
+    government: { _score: 2000 },
+    hospital: { _score: 2000 },
+    train_station: { _score: 5000 },
+    transportation: { _score: 2000 },
+    university: { _score: 2000 },
+    public: { _score: 2000 },
+    sports_hall: { _score: 2000 },
+  },
+  height: { _score: 2000 },
+  start_date: { _score: 2000 },
+  opening_date: { _score: 2000 },
+
+  // properties found on tourist attractions
+  tourism: {
+    visitors: { _score: 2000 },
+    aquarium: { _score: 2000 },
+    attraction: { _score: 1000 },
+    museum: { _score: 2000 },
+    theme_park: { _score: 2000 },
+    zoo: { _score: 2000 },
+    _score: 1000
+  },
+  museum: { _score: 2000 },
+  museum_type: { _score: 2000 },
+  opening_hours: { _score: 1000 },
+  operator: { _score: 1000 },
+  fee: { _score: 2000 },
+
+  // closed and abandoned places
+  // https://wiki.openstreetmap.org/wiki/Key:disused:
+  disused: { _score: -100000 },
+  'disused:shop': { _score: -100000 },
+  'disused:amenity': { _score: -100000 },
+  'disused:railway': { _score: -100000 },
+  'disused:leisure': { _score: -100000 },
+  // https://wiki.openstreetmap.org/wiki/Key:abandoned:
+  abandoned: { _score: -100000 },
+  'abandoned:shop': { _score: -100000 },
+  'abandoned:amenity': { _score: -100000 },
+  'abandoned:railway': { _score: -100000 },
+  'abandoned:leisure': { _score: -100000 },
+
+  // types of public amenities
+  amenity: {
+    disused: { _score: -100000 },
+    college: { _score: 2000 },
+    library: { _score: 2000 },
+    school: { _score: 1000 },
+    university: { _score: 2000 },
+    bank: { _score: 1000 },
+    clinic: { _score: 1000 },
+    dentist: { _score: 1000 },
+    doctors: { _score: 1000 },
+    hospital: { _score: 2000 },
+    nursing_home: { _score: 1000 },
+    pharmacy: { _score: 1000 },
+    social_facility: { _score: 1000 },
+    veterinary: { _score: 1000 },
+    community_centre: { _score: 1000 },
+    music_venue: { _score: 1000 },
+    nightclub: { _score: 1000 },
+    planetarium: { _score: 1000 },
+    social_centre: { _score: 1000 },
+    theatre: { _score: 1000 },
+    courthouse: { _score: 1000 },
+    coworking_space: { _score: 1000 },
+    dojo: { _score: 1000 },
+    embassy: { _score: 1000 },
+    fire_station: { _score: 1000 },
+    marketplace: { _score: 1000 },
+    place_of_worship: { _score: 1000 },
+    police: { _score: 1000 },
+    post_office: { _score: 1000 },
+    prison: { _score: 1000 },
+    public_bath: { _score: 1000 },
+    townhall: { _score: 1000 }
+  },
+
+  // contact information
+  website: { _score: 2000 },
+  phone: { _score: 1000 },
+  'contact:website': { _score: 2000 },
+  'contact:email': { _score: 1000 },
+  'contact:phone': { _score: 1000 },
+  'contact:fax': { _score: 1000 },
+
+  // social media
+  'contact:foursquare': { _score: 2000 },
+  'contact:facebook': { _score: 2000 },
+  'contact:linkedin': { _score: 2000 },
+  'contact:instagram': { _score: 2000 },
+  'contact:skype': { _score: 2000 },
+  'contact:flickr': { _score: 2000 },
+  'contact:youtube': { _score: 2000 },
+};
+
+module.exports = function(){
+
+  return through.obj(( doc, enc, next ) => {
+
+    try {
+
+      // only map venues
+      if( doc.getLayer() !== 'venue' ){
+        return next(null, doc);
+      }
+
+      // skip records with no tags
+      let tags = doc.getMeta('tags');
+      if( !tags ){
+        return next( null, doc );
+      }
+
+      // default popularity
+      let popularity = doc.getPopularity() || 0;
+
+      // apply scores from config
+      for( let tag in config ){
+        if( tags.hasOwnProperty( tag ) ){
+          // global score for the tag
+          if( config[tag]._score ){
+            popularity += config[tag]._score;
+          }
+          // individual scores for specific values
+          for( let value in config[tag] ){
+            if( value === '_score' ){ continue; }
+            if( !config[tag][value]._score ){ continue; }
+            if( tags[tag] === value.trim() ){
+              popularity += config[tag][value]._score;
+            }
+          }
+        }
+      }
+
+      // set document popularity when it is a non-zero value
+      if( !!popularity ){
+        doc.setPopularity( popularity );
+      }
+    }
+
+    catch( e ){
+      peliasLogger.error( 'popularity_mapper error' );
+      peliasLogger.error( e.stack );
+      peliasLogger.error( JSON.stringify( doc, null, 2 ) );
+    }
+
+    // discard disused and abandoned places with a negative popularity
+    if(( doc.getPopularity() || 0 ) < 0 ){
+      return next();
+    }
+
+    return next( null, doc );
+
+  });
+
+};

--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -109,6 +109,7 @@ const config = {
     coworking_space: { _score: 1000 },
     dojo: { _score: 1000 },
     embassy: { _score: 1000 },
+    ferry_terminal: { _score: 2000 },
     fire_station: { _score: 1000 },
     marketplace: { _score: 1000 },
     place_of_worship: { _score: 1000 },
@@ -117,6 +118,20 @@ const config = {
     prison: { _score: 1000 },
     public_bath: { _score: 1000 },
     townhall: { _score: 1000 }
+  },
+
+  // transportation
+  aerodrome: {
+    international: { _score: 10000 },
+    regional: { _score: 5000 }
+  },
+  iata: {
+    _score: 5000,
+    none: { _score: -5000 }
+  },
+  railway: {
+    station: { _score: 2000 },
+    subway_entrance: { _score: 2000 },
   },
 
   // contact information
@@ -168,7 +183,7 @@ module.exports = function(){
           for( let value in config[tag] ){
             if( value === '_score' ){ continue; }
             if( !config[tag][value]._score ){ continue; }
-            if( tags[tag] === value.trim() ){
+            if (tags[tag].trim().toLowerCase() === value ){
               popularity += config[tag][value]._score;
             }
           }

--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -135,21 +135,21 @@ const config = {
   },
 
   // contact information
-  website: { _score: 2000 },
-  phone: { _score: 1000 },
-  'contact:website': { _score: 2000 },
-  'contact:email': { _score: 1000 },
-  'contact:phone': { _score: 1000 },
-  'contact:fax': { _score: 1000 },
+  website: { _score: 200 },
+  phone: { _score: 200 },
+  'contact:website': { _score: 200 },
+  'contact:email': { _score: 200 },
+  'contact:phone': { _score: 200 },
+  'contact:fax': { _score: 200 },
 
   // social media
-  'contact:foursquare': { _score: 2000 },
-  'contact:facebook': { _score: 2000 },
-  'contact:linkedin': { _score: 2000 },
-  'contact:instagram': { _score: 2000 },
-  'contact:skype': { _score: 2000 },
-  'contact:flickr': { _score: 2000 },
-  'contact:youtube': { _score: 2000 },
+  'contact:foursquare': { _score: 200 },
+  'contact:facebook': { _score: 200 },
+  'contact:linkedin': { _score: 200 },
+  'contact:instagram': { _score: 200 },
+  'contact:skype': { _score: 200 },
+  'contact:flickr': { _score: 200 },
+  'contact:youtube': { _score: 200 },
 };
 
 module.exports = function(){

--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -190,10 +190,11 @@ module.exports = function(){
         }
       }
 
-      // set document popularity when it is a non-zero value
-      if( !!popularity ){
-        doc.setPopularity( popularity );
-      }
+      // set document popularity if it is greater than zero
+      if( popularity > 0 ){ doc.setPopularity( popularity ); }
+
+      // discard places with a negative popularity
+      else if( popularity < 0 ){ return next(); }
     }
 
     catch( e ){
@@ -202,13 +203,7 @@ module.exports = function(){
       peliasLogger.error( JSON.stringify( doc, null, 2 ) );
     }
 
-    // discard disused and abandoned places with a negative popularity
-    if(( doc.getPopularity() || 0 ) < 0 ){
-      return next();
-    }
-
     return next( null, doc );
-
   });
 
 };

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -105,7 +105,6 @@ module.exports = function(){
           if( iata ){
             doc.setNameAlias( 'default', iata );
             doc.setNameAlias( 'default', `${iata} Airport` );
-            doc.setPopularity(10000);
           }
         }
       }

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -52,6 +52,7 @@ streams.pbfParser()
   .pipe( streams.addressExtractor() )
   .pipe( streams.categoryMapper( streams.config.categoryDefaults ) )
   .pipe( streams.addendumMapper() )
+  .pipe( streams.popularityMapper() )
   .pipe( model.createDocumentMapperStream() )
   .pipe( sink.obj(function (doc) {
     results.push(doc);

--- a/test/run.js
+++ b/test/run.js
@@ -11,6 +11,7 @@ var tests = [
   require('./stream/address_extractor'),
   require('./stream/category_mapper'),
   require('./stream/addendum_mapper'),
+  require('./stream/popularity_mapper'),
   require('./stream/document_constructor'),
   require('./stream/importPipeline'),
   require('./stream/pbf'),

--- a/test/stream/importPipeline.js
+++ b/test/stream/importPipeline.js
@@ -16,6 +16,7 @@ module.exports.tests.interface = function(test, common) {
     'addressExtractor',
     'categoryMapper',
     'addendumMapper',
+    'popularityMapper',
     'dbMapper',
     'elasticsearch',
     'import'

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -134,6 +134,50 @@ module.exports.tests.contact_phone = function (test, common) {
   });
 };
 
+// ===================== transportation ======================
+
+module.exports.tests.international_airport = function(test, common) {
+  var doc = new Document('a','venue',1);
+  doc.setMeta('tags', { 'aerodrome': 'international', 'iata': 'JFK' });
+  test('alias - international airport', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.deepEqual(doc.getPopularity(), 15000);
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.regional_airport = function (test, common) {
+  var doc = new Document('a', 'venue', 1);
+  doc.setMeta('tags', { 'aerodrome': 'regional', 'iata': 'None' });
+  test('alias - regional airport (invalid IATA code)', function (t) {
+    var stream = mapper();
+    stream.pipe(through.obj(function (doc, enc, next) {
+      t.deepEqual(doc.getPopularity(), 5000);
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.railway_station = function (test, common) {
+  var doc = new Document('a', 'venue', 1);
+  doc.setMeta('tags', { 'railway': 'station' });
+  test('alias - railway station', function (t) {
+    var stream = mapper();
+    stream.pipe(through.obj(function (doc, enc, next) {
+      t.deepEqual(doc.getPopularity(), 2000);
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 // ===================== do not map non-venue docs ======================
 
 module.exports.tests.nonvenue = function (test, common) {

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -197,32 +197,42 @@ module.exports.tests.nonvenue = function (test, common) {
 // ===================== discard disused places ======================
 
 module.exports.tests.disused = function (test, common) {
-  var doc = new Document('osm', 'address', 1);
+  var doc = new Document('osm', 'venue', 1);
   doc.setMeta('tags', { 'disused:amenity': 'yes' });
   test('does not map - disused', t => {
     var stream = mapper();
+    var counter = 0;
     stream.pipe(through.obj((doc, enc, next) => {
-      t.false(doc.getPopularity(), 'no mapping performed');
-      t.end(); // test will fail if not called (or called twice).
+      counter++;
       next();
+    }, (done) => {
+      t.equal(counter, 0, 'document discarded');
+      t.end(); // test will fail if not called (or called twice).
+      done();
     }));
     stream.write(doc);
+    stream.end();
   });
 };
 
 // ===================== discard abandoned places ======================
 
 module.exports.tests.abandoned = function (test, common) {
-  var doc = new Document('osm', 'address', 1);
+  var doc = new Document('osm', 'venue', 1);
   doc.setMeta('tags', { 'abandoned:amenity': 'yes' });
   test('does not map - abandoned', t => {
     var stream = mapper();
+    var counter = 0;
     stream.pipe(through.obj((doc, enc, next) => {
-      t.false(doc.getPopularity(), 'no mapping performed');
-      t.end(); // test will fail if not called (or called twice).
+      counter++;
       next();
+    }, (done) => {
+      t.equal(counter, 0, 'document discarded');
+      t.end(); // test will fail if not called (or called twice).
+      done();
     }));
     stream.write(doc);
+    stream.end();
   });
 };
 

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -126,7 +126,7 @@ module.exports.tests.contact_phone = function (test, common) {
   test('maps - contact:phone', t => {
     var stream = mapper();
     stream.pipe(through.obj((doc, enc, next) => {
-      t.deepEqual(doc.getPopularity(), 1000, 'correctly mapped');
+      t.deepEqual(doc.getPopularity(), 200, 'correctly mapped');
       t.end(); // test will fail if not called (or called twice).
       next();
     }));

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -196,7 +196,7 @@ module.exports.tests.nonvenue = function (test, common) {
 
 // ===================== discard disused places ======================
 
-module.exports.tests.nonvenue = function (test, common) {
+module.exports.tests.disused = function (test, common) {
   var doc = new Document('osm', 'address', 1);
   doc.setMeta('tags', { 'disused:amenity': 'yes' });
   test('does not map - disused', t => {
@@ -212,7 +212,7 @@ module.exports.tests.nonvenue = function (test, common) {
 
 // ===================== discard abandoned places ======================
 
-module.exports.tests.nonvenue = function (test, common) {
+module.exports.tests.abandoned = function (test, common) {
   var doc = new Document('osm', 'address', 1);
   doc.setMeta('tags', { 'abandoned:amenity': 'yes' });
   test('does not map - abandoned', t => {

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -1,0 +1,214 @@
+const through = require('through2');
+const mapper = require('../../stream/popularity_mapper');
+const ixtures = require('../fixtures/docs');
+const Document = require('pelias-model').Document;
+
+module.exports.tests = {};
+
+// test exports
+module.exports.tests.interface = function (test, common) {
+  test('interface: factory', t => {
+    t.equal(typeof mapper, 'function', 'stream factory');
+    t.end();
+  });
+  test('interface: stream', t => {
+    var stream = mapper();
+    t.equal(typeof stream, 'object', 'valid stream');
+    t.equal(typeof stream._read, 'function', 'valid readable');
+    t.equal(typeof stream._write, 'function', 'valid writeable');
+    t.end();
+  });
+};
+
+// ===================== popularity mapping ======================
+
+module.exports.tests.importance_international = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'importance': 'international' });
+  test('maps - importance_international', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 50000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.importance_national = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'importance': 'national' });
+  test('maps - importance_national', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 10000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.wikidata = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'wikidata': 'Q1371018' });
+  test('maps - wikidata', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 3000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.wikipedia = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'wikipedia': 'it:Aeroporto di Perugia' });
+  test('maps - wikipedia', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 3000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.building_hospital = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'building': 'hospital' });
+  test('maps - building:hospital', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 2000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.tourism_aquarium = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'tourism': 'aquarium' });
+  test('maps - tourism:aquarium', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 3000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.amenity_post_office = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'amenity': 'post_office' });
+  test('maps - amenity:post_office', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 1000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.contact_phone = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'contact:phone': '555-5555' });
+  test('maps - contact:phone', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 1000, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ===================== do not map non-venue docs ======================
+
+module.exports.tests.nonvenue = function (test, common) {
+  var doc = new Document('osm', 'address', 1);
+  doc.setMeta('tags', { 'importance': 'international' });
+  test('does not map - non-venue', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.false(doc.getPopularity(), 'no mapping performed');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ===================== discard disused places ======================
+
+module.exports.tests.nonvenue = function (test, common) {
+  var doc = new Document('osm', 'address', 1);
+  doc.setMeta('tags', { 'disused:amenity': 'yes' });
+  test('does not map - disused', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.false(doc.getPopularity(), 'no mapping performed');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ===================== discard abandoned places ======================
+
+module.exports.tests.nonvenue = function (test, common) {
+  var doc = new Document('osm', 'address', 1);
+  doc.setMeta('tags', { 'abandoned:amenity': 'yes' });
+  test('does not map - abandoned', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.false(doc.getPopularity(), 'no mapping performed');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ======================= errors ========================
+
+// catch general errors in the stream, emit logs and passthrough the doc
+module.exports.tests.catch_thrown_errors = function (test, common) {
+  test('errors - catch thrown errors', t => {
+    var doc = new Document('osm', 'venue', 1);
+
+    // this method will throw a generic Error for testing
+    doc.getMeta = function () { throw new Error('test'); };
+
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getLayer(), 'venue', 'doc passthrough');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('popularity_mapper: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -247,7 +247,6 @@ module.exports.tests.airport_codes = function(test, common) {
     stream.pipe( through.obj( function( doc, enc, next ){
       t.equal(doc.getName('default'), 'test', 'correctly mapped');
       t.deepEqual(doc.getNameAliases('default'), ['FOO', 'FOO Airport'], 'correctly mapped');
-      t.deepEqual(doc.getPopularity(), 10000);
       t.end(); // test will fail if not called (or called twice).
       next();
     }));


### PR DESCRIPTION
This feature has been requested in https://github.com/pelias/pelias/issues/171

This PR adds the ability to increase a document `popularity` score based on which tags it has.

I'd love to see some suggestions from the community on what they would like to see regarding 'importance' scoring in OSM.
Please suggest additional tags and scoring methodologies!

I will tune the final numbers in testing, these numbers are normalized using `log1p` before the scoring is applied in elasticsearch.
We should only really use these numbers as a 'tie-breaker' for multiple venues with the same name, eg `Eiffel Tower`

I also added some functionality to detect `abandoned` and `disused` places and give them negative popularity.
In the case where a document has negative popularity, it is discarded.

resolves https://github.com/pelias/pelias/issues/171