### PR TITLE
tests(address-extractor) replace event-stream with stream-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "colors": "^1.1.2",
     "deep-diff": "^1.0.0",
-    "event-stream": "^4.0.0",
+    "stream-mock": "^2.0.3",
     "istanbul": "^0.4.3",
     "jshint": "^2.8.0",
     "naivedb": "^1.0.7",

--- a/test/stream/address_extractor.js
+++ b/test/stream/address_extractor.js
@@ -3,13 +3,14 @@ var extractor = require('../../stream/address_extractor');
 var fixtures = require('../fixtures/docs');
 var Document = require('pelias-model').Document;
 var through = require('through2');
-var event_stream = require( 'event-stream' );
+const stream_mock = require('stream-mock');
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 module.exports.tests = {};


### PR DESCRIPTION
Replacing `event-stream` with `stream-mock` as discussed in https://github.com/pelias/pelias/issues/801 