### PR TITLE
chore(package.json): Remove obsolete `engines` specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "pelias-openstreetmap",
   "version": "0.0.0-development",
   "engines": {
-    "node": ">=8.0.0",
-    "npm": ">=1.4.3",
-    "elasticsearch": ">=1.3.4"
+    "node": ">=8.0.0"
   },
   "author": "pelias",
   "description": "Pelias openstreetmap utilities",


### PR DESCRIPTION
For a long time we have been specifying requirements on very old
versions of Elasticsearch and NPM. Only the NPM specification was even
valid, and at this point the version numbers have fallen far behind.

We generally should support whichever NPM version comes with the
versions of Node.js we support, so it's no longer useful to specify
either of these.
