### PR TITLE
chore(tests): Update test expectations for new doc type name

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "merge": "^1.2.0",
     "pbf2json": "^6.1.0",
     "pelias-blacklist-stream": "^1.0.0",
-    "pelias-config": "^4.5.0",
+    "pelias-config": "^4.8.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^7.1.0",


### PR DESCRIPTION
As of `pelias-config@4.8.0`, the default Elasticsearch type name is now `_doc`, which is the value compatible with Elasticsearch 7.

This PR updates the functional tests to expect that new value.

Connects https://github.com/pelias/config/pull/122
Connects https://github.com/pelias/pelias/issues/831
Fixes https://github.com/pelias/openstreetmap/issues/513