### PR TITLE
feat(logs): Remove verbose address extractor log

### DIFF
--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -94,10 +94,6 @@ module.exports = function(){
       this.push( doc );
     }
 
-    if ( isAddress && isNamedPoi ) {
-      peliasLogger.verbose('[address_extractor] duplicating a venue with address');
-    }
-
     return next();
 
   });


### PR DESCRIPTION
If using the `verbose` log level or above, this importer will print many log lines like the following:

```
2020-04-22T02:34:12.254Z - verbose: [openstreetmap] [address_extractor]
duplicating a venue with address
2020-04-22T02:34:12.254Z - verbose: [openstreetmap] [address_extractor]
duplicating a venue with address
```

These log lines don't really add any value, as they record an extremely normal and common occurrence.

If we wanted to count how many address records came from duplicating a venue, we could do so, but it might make more sense to print a single count at the end.