### PR TITLE
Add two new OSM venue tags; add operator/brand to addendum

### DIFF
--- a/config/features.js
+++ b/config/features.js
@@ -44,7 +44,9 @@ var venue_tags = [
   'aeroway~spaceport+name',
   'aeroway~landing_strip+name',
   'aeroway~airfield+name',
-  'aeroway~airport+name'
+  'aeroway~airport+name',
+  'brand+name',
+  'healthcare+name'
 ];
 
 module.exports = {tags,venue_tags};

--- a/stream/addendum_mapper.js
+++ b/stream/addendum_mapper.js
@@ -13,6 +13,8 @@ const whitelist = [
   'icao', // ICAO airport codes
   'wikidata', // Wikidata concordance
   'wikipedia', // Wikipedia concordance
+  'operator', // Operator name
+  'brand', // Brand name
   // 'website', // Website URL
   // 'phone', // Telephone number
   // 'opening_hours', // Opening hours

--- a/test/config/features.js
+++ b/test/config/features.js
@@ -68,6 +68,8 @@ module.exports.tests.whitelist = function(test, common) {
     t.false( features.venue_tags.indexOf('aeroway~landing_strip+name') <0 );
     t.false( features.venue_tags.indexOf('aeroway~airfield+name') <0 );
     t.false( features.venue_tags.indexOf('aeroway~airport+name') <0 );
+    t.false( features.venue_tags.indexOf('brand+name') <0 );
+    t.false( features.venue_tags.indexOf('healthcare+name') <0 );
     t.end();
   });
 };

--- a/test/stream/addendum_mapper.js
+++ b/test/stream/addendum_mapper.js
@@ -92,6 +92,34 @@ module.exports.tests.wikipedia = function (test, common) {
   });
 };
 
+module.exports.tests.brand = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'brand': '99 Ranch Market' });
+  test('maps - brand', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { brand: '99 Ranch Market' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.operator = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'operator': 'YMCA' });
+  test('maps - operator', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { operator: 'YMCA' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 // ======================= errors ========================
 
 // catch general errors in the stream, emit logs and passthrough the doc


### PR DESCRIPTION
Closes #527 

I tested locally using the `portland-metro` project data (504k total records; 36621 venues); after adding brand + operator to the addendum the index size grew by ~0.27% (+~0.3 MB, from 111.95mb -> 112.25mb).

When updating the data used by the end-to-end tests I noticed a couple of new addresses were contained in the output, which I wasn't really expecting...  they appear to be addresses indexed from new venues that were pulled in, eg `relation/6066047`.   I assume this is expected; let me know if not.

Thanks!