### PR TITLE
additional addendum fields

### DIFF
--- a/config/features.js
+++ b/config/features.js
@@ -5,12 +5,12 @@
 **/
 
 // default tags imported
-var tags = [
+const tags = [
   'addr:housenumber+addr:street'
 ];
 
 // tags corresponding to venues
-var venue_tags = [
+const venue_tags = [
   'amenity+name',
   'building+name',
   'shop+name',

--- a/stream/addendum_mapper.js
+++ b/stream/addendum_mapper.js
@@ -15,9 +15,9 @@ const whitelist = [
   'wikipedia', // Wikipedia concordance
   'operator', // Operator name
   'brand', // Brand name
-  // 'website', // Website URL
-  // 'phone', // Telephone number
-  // 'opening_hours', // Opening hours
+  'website', // Website URL
+  'phone', // Telephone number
+  'opening_hours', // Opening hours
 ];
 
 module.exports = function(){

--- a/test/config/features.js
+++ b/test/config/features.js
@@ -1,5 +1,4 @@
-
-var features = require('../../config/features');
+const features = require('../../config/features');
 
 module.exports.tests = {};
 
@@ -15,10 +14,10 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.blacklist = function(test, common) {
   test('blacklist default tags', function(t) {
     // see: https://github.com/pelias/openstreetmap/pull/280
-    t.true( features.tags.indexOf('aeroway+name') <0 );
-    t.true( features.tags.indexOf('aeroway~gate+name') <0 );
-    t.true( features.tags.indexOf('railway+name') <0 );
-    t.true( features.tags.indexOf('railway~rail+name') <0 );
+    t.false( features.tags.includes('aeroway+name') );
+    t.false( features.tags.includes('aeroway~gate+name') );
+    t.false( features.tags.includes('railway+name') );
+    t.false( features.tags.includes('railway~rail+name') );
     t.end();
   });
 };
@@ -27,49 +26,49 @@ module.exports.tests.blacklist = function(test, common) {
 // we exclude by default tags corresponding to venues
 module.exports.tests.whitelist = function(test, common) {
   test('whitelist default tags', function(t) {
-    t.false( features.tags.indexOf('addr:housenumber+addr:street') <0 );
-    t.true( features.venue_tags.indexOf('amenity+name') <0 );
+    t.true( features.tags.includes('addr:housenumber+addr:street') );
+    t.false( features.tags.includes('amenity+name') );
     t.end();
   });
 };
 
 // ensure some venue tags are included
-module.exports.tests.whitelist = function(test, common) {
+module.exports.tests.whitelist_venue_tags = function(test, common) {
   test('whitelist venue tags', function(t) {
-    t.false( features.venue_tags.indexOf('amenity+name') <0 );
-    t.false( features.venue_tags.indexOf('building+name') <0 );
-    t.false( features.venue_tags.indexOf('shop+name') <0 );
-    t.false( features.venue_tags.indexOf('office+name') <0 );
-    t.false( features.venue_tags.indexOf('public_transport+name') <0 );
-    t.false( features.venue_tags.indexOf('cuisine+name') <0 );
-    t.false( features.venue_tags.indexOf('railway~tram_stop+name') <0 );
-    t.false( features.venue_tags.indexOf('railway~station+name') <0 );
-    t.false( features.venue_tags.indexOf('railway~halt+name') <0 );
-    t.false( features.venue_tags.indexOf('railway~subway_entrance+name') <0 );
-    t.false( features.venue_tags.indexOf('railway~train_station_entrance+name') <0 );
-    t.false( features.venue_tags.indexOf('sport+name') <0 );
-    t.false( features.venue_tags.indexOf('natural+name') <0 );
-    t.false( features.venue_tags.indexOf('tourism+name') <0 );
-    t.false( features.venue_tags.indexOf('leisure+name') <0 );
-    t.false( features.venue_tags.indexOf('historic+name') <0 );
-    t.false( features.venue_tags.indexOf('man_made+name') <0 );
-    t.false( features.venue_tags.indexOf('landuse+name') <0 );
-    t.false( features.venue_tags.indexOf('waterway+name') <0 );
-    t.false( features.venue_tags.indexOf('aerialway+name') <0 );
-    t.false( features.venue_tags.indexOf('craft+name') <0 );
-    t.false( features.venue_tags.indexOf('military+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~terminal+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~aerodrome+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~helipad+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~airstrip+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~heliport+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~areodrome+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~spaceport+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~landing_strip+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~airfield+name') <0 );
-    t.false( features.venue_tags.indexOf('aeroway~airport+name') <0 );
-    t.false( features.venue_tags.indexOf('brand+name') <0 );
-    t.false( features.venue_tags.indexOf('healthcare+name') <0 );
+    t.true( features.venue_tags.includes('amenity+name') );
+    t.true( features.venue_tags.includes('building+name') );
+    t.true( features.venue_tags.includes('shop+name') );
+    t.true( features.venue_tags.includes('office+name') );
+    t.true( features.venue_tags.includes('public_transport+name') );
+    t.true( features.venue_tags.includes('cuisine+name') );
+    t.true( features.venue_tags.includes('railway~tram_stop+name') );
+    t.true( features.venue_tags.includes('railway~station+name') );
+    t.true( features.venue_tags.includes('railway~halt+name') );
+    t.true( features.venue_tags.includes('railway~subway_entrance+name') );
+    t.true( features.venue_tags.includes('railway~train_station_entrance+name') );
+    t.true( features.venue_tags.includes('sport+name') );
+    t.true( features.venue_tags.includes('natural+name') );
+    t.true( features.venue_tags.includes('tourism+name') );
+    t.true( features.venue_tags.includes('leisure+name') );
+    t.true( features.venue_tags.includes('historic+name') );
+    t.true( features.venue_tags.includes('man_made+name') );
+    t.true( features.venue_tags.includes('landuse+name') );
+    t.true( features.venue_tags.includes('waterway+name') );
+    t.true( features.venue_tags.includes('aerialway+name') );
+    t.true( features.venue_tags.includes('craft+name') );
+    t.true( features.venue_tags.includes('military+name') );
+    t.true( features.venue_tags.includes('aeroway~terminal+name') );
+    t.true( features.venue_tags.includes('aeroway~aerodrome+name') );
+    t.true( features.venue_tags.includes('aeroway~helipad+name') );
+    t.true( features.venue_tags.includes('aeroway~airstrip+name') );
+    t.true( features.venue_tags.includes('aeroway~heliport+name') );
+    t.true( features.venue_tags.includes('aeroway~areodrome+name') );
+    t.true( features.venue_tags.includes('aeroway~spaceport+name') );
+    t.true( features.venue_tags.includes('aeroway~landing_strip+name') );
+    t.true( features.venue_tags.includes('aeroway~airfield+name') );
+    t.true( features.venue_tags.includes('aeroway~airport+name') );
+    t.true( features.venue_tags.includes('brand+name') );
+    t.true( features.venue_tags.includes('healthcare+name') );
     t.end();
   });
 };

--- a/test/stream/addendum_mapper.js
+++ b/test/stream/addendum_mapper.js
@@ -92,6 +92,7 @@ module.exports.tests.wikipedia = function (test, common) {
   });
 };
 
+
 module.exports.tests.brand = function (test, common) {
   var doc = new Document('osm', 'a', 1);
   doc.setMeta('tags', { 'brand': '99 Ranch Market' });
@@ -113,6 +114,50 @@ module.exports.tests.operator = function (test, common) {
     var stream = mapper();
     stream.pipe(through.obj((doc, enc, next) => {
       t.deepEqual(doc.addendum.osm, { operator: 'YMCA' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ===================== contact details ======================
+
+module.exports.tests.website = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'website': 'https://example.com' });
+  test('maps - website', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { website: 'https://example.com' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.phone = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'phone': '555-5555' });
+  test('maps - phone', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { phone: '555-5555' }, 'correctly mapped');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.opening_hours = function (test, common) {
+  var doc = new Document('osm', 'a', 1);
+  doc.setMeta('tags', { 'opening_hours': '24/7' });
+  test('maps - opening_hours', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.addendum.osm, { opening_hours: '24/7' }, 'correctly mapped');
       t.end(); // test will fail if not called (or called twice).
       next();
     }));


### PR DESCRIPTION
following on from https://github.com/pelias/openstreetmap/pull/528 this PR uncomments the three fields I wanted to enable in the past but wasn't sure how much additional disk space would be required.

turns out that addendum fields don't add a lot of bytes.

I also took the liberty to modernize the codebase a bit and fix a test case that wasn't being run due to using a duplicate variable name.