### PR TITLE
feat: Add `covid19` OSM tags as addendum data

### DIFF
--- a/stream/addendum_mapper.js
+++ b/stream/addendum_mapper.js
@@ -18,6 +18,11 @@ const whitelist = [
   'website', // Website URL
   'phone', // Telephone number
   'opening_hours', // Opening hours
+
+  // COVID-19
+  'opening_hours:covid19',
+  'delivery:covid19',
+  'safety:mask:covid19'
 ];
 
 module.exports = function(){


### PR DESCRIPTION
As the first and most obvious step in returning data useful due to COVID-19, we can add some relevant [OSM Tags](https://wiki.openstreetmap.org/wiki/Covid-19_-_how_to_map#Summary_of_main_keys).

Connects https://github.com/pelias/pelias/issues/869