### PR TITLE
fix(deps): Upgrade pelias-model to 7.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pelias-config": "^4.12.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
-    "pelias-model": "^7.1.0",
+    "pelias-model": "^7.2.1",
     "pelias-wof-admin-lookup": "^7.1.1",
     "through2": "^3.0.0",
     "through2-sink": "^1.0.0"


### PR DESCRIPTION
This should help fix _some_ issues associated with https://github.com/pelias/openstreetmap/issues/507, as it will reduce the field length of the `phrase` fields where duplicate values were
previously making it longer that it should have been.