### PR TITLE
Add configuration option to control venue removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Defaults to `tmp`.
 
 By default, the OSM importer imports both venue records and addresses. If set to false, only address records will be imported.
 
+#### `imports.openstreetmap.removeDisusedVenues`
+
+If set to boolean `true`, `venue`s with popularity below `0` (as determined by OSM tags) will be
+discarded. In practice, this affects records with tags such as
+`[disused](https://wiki.openstreetmap.org/wiki/Key:disused#disused:_namespace)`,
+`[amenity:disused](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Ddisused)` and
+`[abandoned](https://wiki.openstreetmap.org/wiki/Key:abandoned:)`
+
+By default, or if set to any other value besides `true`, these records will be imported.
+
 ### Administrative Hierarchy Lookup
 
 OSM records often do not contain information about which city, state (or

--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -10,6 +10,7 @@
 
 const through = require('through2');
 const peliasLogger = require('pelias-logger').get('openstreetmap');
+const peliasConfig = require('pelias-config').generate();
 
 const config = {
   // https://taginfo.openstreetmap.org/keys/importance
@@ -200,7 +201,10 @@ module.exports = function(){
       if( popularity > 0 ){ doc.setPopularity( popularity ); }
 
       // discard places with a negative popularity
-      else if( popularity < 0 ){ return next(); }
+      else if( popularity < 0 && peliasConfig.get('imports.openstreetmap.removeDisusedVenues') === true ){
+        peliasLogger.warn(`removing record ${doc.getGid()} (${doc.getName('default')}) with popularity ${popularity}`);
+        return next();
+      }
     }
 
     catch( e ){


### PR DESCRIPTION
As described in https://github.com/pelias/openstreetmap/issues/537, the default set in https://github.com/pelias/openstreetmap/pull/493, where all venues that have a calculated popularity below `0` are not imported,
is a bit strict.

This adds a config flag, `imports.openstreetmap.removeDisusedVenues` that controls whether or not that behavior is activated.

In addition, when enabled, a `warning` is displayed for each removed record.