### PR TITLE
feat: Add `amenity` OSM tag as addendum data

### DIFF
--- a/stream/addendum_mapper.js
+++ b/stream/addendum_mapper.js
@@ -18,6 +18,7 @@ const whitelist = [
   'website', // Website URL
   'phone', // Telephone number
   'opening_hours', // Opening hours
+  'amenity',
 
   // COVID-19
   'opening_hours:covid19',


### PR DESCRIPTION
Include the OSM amenity tag. It is useful to identify the place type (ex: bank, hospital, school, etc)

https://wiki.openstreetmap.org/wiki/Key:amenity
