### PR TITLE
remove language codes we never used

### DIFF
--- a/schema/name_osm.js
+++ b/schema/name_osm.js
@@ -27,13 +27,15 @@ var OSM_NAMING_SCHEMA = {
   'name':             'default',
   'loc_name':         'default',
   'alt_name':         'default',
-  'int_name':         'international',
-  'nat_name':         'national',
-  'official_name':    'official',
-  'old_name':         'old',
-  'reg_name':         'regional',
   'short_name':       'default',
-  'sorting_name':     'sorting'
+
+  // note: these aliases are currently disabled because they are not being used when querying
+  // 'int_name':         'international',
+  // 'nat_name':         'national',
+  // 'official_name':    'official',
+  // 'old_name':         'old',
+  // 'reg_name':         'regional',
+  // 'sorting_name':     'sorting'
 };
 
 // this property is considered the 'primary name'

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -4,10 +4,10 @@
   document model, using a variety of different schemas found in /schema/*.
 **/
 
-var through = require('through2'),
-    _ = require('lodash'),
-    merge = require('merge'),
-    peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
+const _ = require('lodash');
+const through = require('through2');
+const merge = require('merge');
+const peliasLogger = require('pelias-logger').get('openstreetmap');
 
 var LOCALIZED_NAME_KEYS = require('../config/localized_name_keys');
 var NAME_SCHEMA = require('../schema/name_osm');
@@ -72,10 +72,10 @@ module.exports = function(){
       if( !doc.getName('default') ){
 
         var defaultName =
-          doc.getName('official') ||
-          doc.getName('international') ||
-          doc.getName('national') ||
-          doc.getName('regional') ||
+          _.get(tags, 'official_name') ||
+          _.get(tags, 'int_name') ||
+          _.get(tags, 'nat_name') ||
+          _.get(tags, 'reg_name') ||
           doc.getName('en');
 
         // use one of the preferred name tags listed above

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -1,8 +1,8 @@
 
-var through = require('through2'),
-    mapper = require('../../stream/tag_mapper'),
-    fixtures = require('../fixtures/docs'),
-    Document = require('pelias-model').Document;
+const through = require('through2');
+const mapper = require('../../stream/tag_mapper');
+const fixtures = require('../fixtures/docs');
+const Document = require('pelias-model').Document;
 
 module.exports.tests = {};
 
@@ -65,18 +65,19 @@ module.exports.tests.osm_names = function(test, common) {
     }));
     stream.write(doc);
   });
-  test('maps - name schema', function(t) {
-    var doc = new Document('a','b',1);
-    doc.setMeta('tags', { int_name: 'test1', nat_name: 'test2' });
-    var stream = mapper();
-    stream.pipe( through.obj( function( doc, enc, next ){
-      t.equal(doc.getName('international'), 'test1', 'correctly mapped');
-      t.equal(doc.getName('national'), 'test2', 'correctly mapped');
-      t.end(); // test will fail if not called (or called twice).
-      next();
-    }));
-    stream.write(doc);
-  });
+  // note: these aliases are currently disabled because they are not being used when querying
+  // test('maps - name schema', function(t) {
+  //   var doc = new Document('a','b',1);
+  //   doc.setMeta('tags', { int_name: 'test1', nat_name: 'test2' });
+  //   var stream = mapper();
+  //   stream.pipe( through.obj( function( doc, enc, next ){
+  //     t.equal(doc.getName('international'), 'test1', 'correctly mapped');
+  //     t.equal(doc.getName('national'), 'test2', 'correctly mapped');
+  //     t.end(); // test will fail if not called (or called twice).
+  //     next();
+  //   }));
+  //   stream.write(doc);
+  // });
   test('maps - name aliases', function(t) {
     var doc = new Document('a','b',1);
     doc.setMeta('tags', {
@@ -95,12 +96,15 @@ module.exports.tests.osm_names = function(test, common) {
     stream.pipe( through.obj( function( doc, enc, next ){
       t.equal(doc.getName('default'), 'name', 'correctly mapped');
       t.deepEqual(doc.getNameAliases('default'), ['loc_name','alt_name','short_name'], 'correctly mapped');
-      t.equal(doc.getName('national'), 'nat_name', 'correctly mapped');
-      t.equal(doc.getName('international'), 'int_name', 'correctly mapped');
-      t.equal(doc.getName('official'), 'official_name', 'correctly mapped');
-      t.equal(doc.getName('old'), 'old_name', 'correctly mapped');
-      t.equal(doc.getName('regional'), 'reg_name', 'correctly mapped');
-      t.equal(doc.getName('sorting'), 'sorting_name', 'correctly mapped');
+
+      // note: these aliases are currently disabled because they are not being used when querying
+      // t.equal(doc.getName('national'), 'nat_name', 'correctly mapped');
+      // t.equal(doc.getName('international'), 'int_name', 'correctly mapped');
+      // t.equal(doc.getName('official'), 'official_name', 'correctly mapped');
+      // t.equal(doc.getName('old'), 'old_name', 'correctly mapped');
+      // t.equal(doc.getName('regional'), 'reg_name', 'correctly mapped');
+      // t.equal(doc.getName('sorting'), 'sorting_name', 'correctly mapped');
+
       t.end(); // test will fail if not called (or called twice).
       next();
     }));
@@ -164,10 +168,9 @@ module.exports.tests.use_official_as_fallback_default = function (test, common) 
   test('maps - use name:official as fallback default', function (t) {
     var stream = mapper();
     stream.pipe(through.obj(function (doc, enc, next) {
-      t.equal(doc.getName('default'), 'test3', 'name:en used as fallback');
+      t.equal(doc.getName('default'), 'test3', 'official_name used as fallback');
       t.equal(doc.getName('ru'), 'test1', 'correctly mapped');
       t.equal(doc.getName('en'), 'test2', 'correctly mapped');
-      t.equal(doc.getName('official'), 'test3', 'correctly mapped');
       t.end(); // test will fail if not called (or called twice).
       next();
     }));


### PR DESCRIPTION
These language codes (`international`, `national`, `old` ... etc) were included in the build years ago and never utilised in query logic.

Let's remove them from the index since they're just taking up space?

note: I had to change the tag mapper slightly to ensure the work from https://github.com/pelias/openstreetmap/pull/498 didn't break.