### PR TITLE
use array offset instead of value for address ID generation

### DIFF
--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -58,7 +58,7 @@ module.exports = function(){
         try {
           var newid = [ doc.getSourceId() ];
           if( i > 0 ){
-            newid.push( streetno );
+            newid.push( i );
             peliasLogger.debug('[address_extractor] found multiple house numbers: ', streetNumbers);
           }
 

--- a/stream/address_extractor.js
+++ b/stream/address_extractor.js
@@ -63,7 +63,7 @@ module.exports = function(){
           }
 
           // copy data to new document
-          record = new Document( 'openstreetmap', 'address', newid.join(':') )
+          record = new Document( 'openstreetmap', 'address', newid.join('/') )
             .setName( 'default', streetno + ' ' + doc.address_parts.street )
             .setCentroid( doc.getCentroid() );
 

--- a/test/stream/address_extractor.js
+++ b/test/stream/address_extractor.js
@@ -175,12 +175,12 @@ module.exports.tests.semi_colon_street_numbers = function(test, common) {
       t.equal(actual[0].getName('default'), '1 Pennine Road', 'changed');
       t.equal(actual[0].getAddress('number'), '1', 'single number');
 
-      t.equal(actual[1].getId(), 'item:10:1', 'changed');
+      t.equal(actual[1].getId(), 'item:10/1', 'changed');
       t.equal(actual[1].getLayer(), 'address', 'changed');
       t.equal(actual[1].getName('default'), '2 Pennine Road', 'changed');
       t.equal(actual[1].getAddress('number'), '2', 'single number');
 
-      t.equal(actual[2].getId(), 'item:10:2', 'changed');
+      t.equal(actual[2].getId(), 'item:10/2', 'changed');
       t.equal(actual[2].getLayer(), 'address', 'changed');
       t.equal(actual[2].getName('default'), '3 Pennine Road', 'changed');
       t.equal(actual[2].getAddress('number'), '3', 'single number');

--- a/test/stream/address_extractor.js
+++ b/test/stream/address_extractor.js
@@ -175,12 +175,12 @@ module.exports.tests.semi_colon_street_numbers = function(test, common) {
       t.equal(actual[0].getName('default'), '1 Pennine Road', 'changed');
       t.equal(actual[0].getAddress('number'), '1', 'single number');
 
-      t.equal(actual[1].getId(), 'item:10:2', 'changed');
+      t.equal(actual[1].getId(), 'item:10:1', 'changed');
       t.equal(actual[1].getLayer(), 'address', 'changed');
       t.equal(actual[1].getName('default'), '2 Pennine Road', 'changed');
       t.equal(actual[1].getAddress('number'), '2', 'single number');
 
-      t.equal(actual[2].getId(), 'item:10:3', 'changed');
+      t.equal(actual[2].getId(), 'item:10:2', 'changed');
       t.equal(actual[2].getLayer(), 'address', 'changed');
       t.equal(actual[2].getName('default'), '3 Pennine Road', 'changed');
       t.equal(actual[2].getAddress('number'), '3', 'single number');


### PR DESCRIPTION
while working on https://github.com/pelias/openstreetmap/pull/546 I noticed this, which might be a bug, might be intended, not sure.

a single OSM record can become multiple records in Pelias.
ie. it can become a single `venue` and multiple `address` records.

so we generate a unique ID for each of those records in Pelias.

what's currently happening here is the first `address` has the same ID as the `venue` (if there is one), since its on a different layer it'll get a different GID, all good.

for *subsequent* address records we append the **housenumber value** to the ID:

<img width="467" alt="Screenshot 2020-12-23 at 20 46 51" src="https://user-images.githubusercontent.com/738069/102973108-1320e800-4561-11eb-9015-181193145ad1.png">

I think that is a bit dangerous since the housenumber field is a freeform OSM string which could contain all sorts of characters such as spaces, or `:` which is used as a delimiter in the GID scheme.

This PR changes that to use the array *offset* instead of the array *value*, a subtle difference but it'll ensure that these IDs end with a number and don't contain any punctuation or alpha chars.

I might assign a couple of reviewers here since this slightly changes how we generate IDs, I'm assuming it won't break anything?
