### PR TITLE
set popularity on some address records

### DIFF
--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -166,7 +166,7 @@ module.exports = function(){
     try {
 
       // only map venues
-      if( doc.getLayer() !== 'venue' ){
+      if( !['venue', 'address'].includes(doc.getLayer()) ){
         return next(null, doc);
       }
 
@@ -195,6 +195,12 @@ module.exports = function(){
             }
           }
         }
+      }
+
+      // addresses with a popularity score GTE 10000 receieve
+      // a popularity of 1000, all others get a popularity of 0.
+      if ( doc.getLayer() === 'address' ){
+        popularity = (popularity >= 10000) ? 1000 : 0;
       }
 
       // set document popularity if it is greater than zero

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -202,12 +202,30 @@ module.exports.tests.railway_station = function (test, common) {
 // ===================== do not map non-venue docs ======================
 
 module.exports.tests.nonvenue = function (test, common) {
-  var doc = new Document('osm', 'address', 1);
+  var doc = new Document('osm', 'street', 1);
   doc.setMeta('tags', { 'importance': 'international' });
   test('does not map - non-venue', t => {
     var stream = mapper();
     stream.pipe(through.obj((doc, enc, next) => {
       t.false(doc.getPopularity(), 'no mapping performed');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+// ===================== maps address docs ======================
+// note: currently 1000 is the hard maximum popularity for addresses
+// this restriction may be lifted in the future.
+
+module.exports.tests.address = function (test, common) {
+  var doc = new Document('osm', 'address', 1);
+  doc.setMeta('tags', { 'importance': 'international' });
+  test('does not map - non-venue', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getPopularity(), 1000);
       t.end(); // test will fail if not called (or called twice).
       next();
     }));


### PR DESCRIPTION
this is a fairly simple PR which sets a popularity value for `address` records which are 'popular' by some metric (usually they list contact details or have other metadata denoting that they are a venue).

prior to this PR *only* `venue` records would receive a `popularity`.

this work is motivated by this testcase which returns two valid addresses in Sydney but doesn't put the Sydney Opera House address first (inspecting the ES response shows the scores are currently identical).

<img width="467" alt="Screenshot 2021-02-11 at 12 06 32" src="https://user-images.githubusercontent.com/738069/107586118-382dff00-6c64-11eb-90a5-6cc2a3a2eae9.png">

with this PR a very small scoring difference will occur which will tip the balance in the favour of the Opera House.

note: I have clamped the `popularity` for `address` records to a max of 1000, I didn't want to introduce a wide range of variability in the scoring for them, the rationale for this is discussed in bullet 4 here: https://github.com/pelias/openstreetmap/pull/493#issuecomment-503019975