### PR TITLE
popularity: do not penalize abandoned:amenity=place_of_worship

### DIFF
--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -82,7 +82,12 @@ const config = {
   // https://wiki.openstreetmap.org/wiki/Key:abandoned:
   abandoned: { _score: -100000 },
   'abandoned:shop': { _score: -100000 },
-  'abandoned:amenity': { _score: -100000 },
+  'abandoned:amenity': {
+    // note: some places such as 'Angkor Wat' are tagged 'abandoned:amenity=place_of_worship'.
+    // we use a positive integer to negate the effects of the base _score below (zeroing it out).
+    place_of_worship: { _score: +100000 },
+    _score: -100000
+  },
   'abandoned:railway': { _score: -100000 },
   'abandoned:leisure': { _score: -100000 },
 

--- a/test/stream/popularity_mapper.js
+++ b/test/stream/popularity_mapper.js
@@ -290,6 +290,20 @@ module.exports.tests.abandoned = function (test, common) {
   });
 };
 
+module.exports.tests.abandoned_amenity_place_of_worship = function (test, common) {
+  var doc = new Document('osm', 'venue', 1);
+  doc.setMeta('tags', { 'abandoned:amenity': 'place_of_worship', 'tourism': 'attraction' });
+  test('does not map negative value for - abandoned:amenity=place_of_worship', t => {
+    var stream = mapper();
+    stream.pipe(through.obj(function (doc, enc, next) {
+      t.deepEqual(doc.getPopularity(), 2000);
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 // ======================= errors ========================
 
 // catch general errors in the stream, emit logs and passthrough the doc


### PR DESCRIPTION
As per https://github.com/pelias/geonames/pull/394 this PR is to fix the scoring of the query for "Angkor Wat".

Pelias is currently giving the [OSM record](https://www.openstreetmap.org/way/91217761) a negative popularity as it's tagged `abandoned:amenity=place_of_worship`. 

We originally assumed that `abandoned:amenity` meant it was no longer important but that doesn't seem to be the case, either it's mis-tagged or we're interpreting the tag wrong. The [OSM wiki](https://wiki.openstreetmap.org/wiki/Key:abandoned:) seems to confirm our view, but who knows 🤷‍♂️ .

This PR maintains the negative scoring for all `abandoned` and `abandoned:*` tags with a single exception for `abandoned:amenity=place_of_worship`.

Currently that only affects [421 records](https://taginfo.openstreetmap.org/keys/abandoned:amenity#values) so it's unlikely to have any negative side-effects.