### PR TITLE
chore: upgrade pelias-model to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pelias-config": "^4.12.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
-    "pelias-model": "^7.2.1",
+    "pelias-model": "^9.1.1",
     "pelias-wof-admin-lookup": "^7.4.1",
     "through2": "^3.0.0",
     "through2-sink": "^1.0.0"


### PR DESCRIPTION
I was investigating why the autocomplete query "Statue of Liberty" was not returning https://www.openstreetmap.org/way/32965412 when I discovered that the `pelias/model` version was well out-of-date and missing some features from the last year or so.

We were pinning `^7.2.1` which is from `10 June 2020`, this PR brings it up-to-date with the latest `^9.1.0`

<img width="727" alt="Screenshot 2021-07-20 at 13 13 10" src="https://user-images.githubusercontent.com/738069/126314726-9b45ae6c-4ae7-4bf1-874a-1d853e6c2b45.png">

https://github.com/pelias/model/tags

In particular `8.1.0` is very beneficial because it will reduce some of the TF/IDF scoring issues such as for the Statue of Liberty.