### PR TITLE
upgrade pbf2json to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "joi": "^14.0.0",
     "lodash": "^4.17.4",
     "merge": "^1.2.0",
-    "pbf2json": "^6.1.0",
+    "pbf2json": "^6.9.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^4.12.0",
     "pelias-dbclient": "^2.13.0",


### PR DESCRIPTION
upgrade pbf2json to latest version

prior to https://github.com/pelias/pbf2json/pull/99 the builds were being produced manually, so this should have a couple effects:
- bring in a more stable version which we know was built by CI
- brings in [changes since the previous version](https://github.com/pelias/pbf2json/releases).

the `end-to-end` and `unit` tests showed no changes so it seems to be innocuous 
[edit] hmm well at least locally 🤷 

It's hard to tell which version we are currently running in docker images but this is more explicit and avoids `6.8.0` which had a binary packing issue.