### PR TITLE
tag_mapper: skip inherited enumerable properties

### DIFF
--- a/config/category_map.js
+++ b/config/category_map.js
@@ -17,7 +17,7 @@
  @see: https://github.com/pelias/pelias/wiki/Taxonomy-v1
 **/
 
-var mapping = {
+const mapping = {
 
   'aerialway': {
     '*':                        ['transport'],

--- a/config/localized_name_keys.js
+++ b/config/localized_name_keys.js
@@ -30,14 +30,15 @@
   @see: http://wiki.openstreetmap.org/wiki/Talk:Names
 **/
 
-var iso6393 = require('iso-639-3');
-var keys = [];
+const _ = require('lodash');
+const iso6393 = require('iso-639-3');
+const keys = [];
 
-for( var i in iso6393 ){
-  var code = iso6393[i].iso6391;
+_.each(iso6393, (lang) => {
+  let code = _.get(lang, 'iso6391');
   if( code ){
     keys.push( code );
   }
-}
+});
 
 module.exports = keys;

--- a/config/popularity_map.js
+++ b/config/popularity_map.js
@@ -1,0 +1,163 @@
+/**
+  The popularity mapper is responsible for generating a 'popularity'
+  value by inspecting OSM tags.
+
+  Disused and abandoned places are given a strong negative score.
+  If the popularity score is less than zero then the document is discarded.
+
+  Feel free to make changes to this mapping file!
+**/
+
+const mapping = {
+  // https://taginfo.openstreetmap.org/keys/importance
+  importance: {
+    international: { _score: 50000 },
+    national: { _score: 10000 },
+    regional: { _score: 5000 },
+    urban: { _score: 1000 },
+    suburban: { _score: 500 },
+    local: { _score: 100 },
+  },
+
+  // concordances
+  wikipedia: { _score: 3000 },
+  wikidata: { _score: 3000 },
+
+  // properties found on major landmarks &
+  // public buildings.
+  architect: { _score: 5000 },
+  heritage: { _score: 5000 },
+  'heritage:operator': { _score: 2000 },
+  historic: {
+    building: { _score: 5000 },
+    church: { _score: 5000 },
+    heritage: { _score: 7000 },
+    _score: 1000,
+  },
+  building: {
+    colour: { _score: 2000 },
+    material: { _score: 2000 },
+    supermarket: { _score: 2000 },
+    civic: { _score: 2000 },
+    government: { _score: 2000 },
+    hospital: { _score: 2000 },
+    train_station: { _score: 5000 },
+    transportation: { _score: 2000 },
+    university: { _score: 2000 },
+    public: { _score: 2000 },
+    sports_hall: { _score: 2000 },
+    historic: { _score: 5000 },
+  },
+  height: { _score: 2000 },
+  start_date: { _score: 2000 },
+  opening_date: { _score: 2000 },
+
+  // properties found on tourist attractions
+  tourism: {
+    visitors: { _score: 2000 },
+    aquarium: { _score: 2000 },
+    attraction: { _score: 1000 },
+    museum: { _score: 2000 },
+    theme_park: { _score: 2000 },
+    zoo: { _score: 2000 },
+    _score: 1000
+  },
+  museum: { _score: 2000 },
+  museum_type: { _score: 2000 },
+  opening_hours: { _score: 1000 },
+  operator: { _score: 1000 },
+  fee: { _score: 2000 },
+
+  // closed and abandoned places
+  // https://wiki.openstreetmap.org/wiki/Key:disused:
+  disused: { _score: -100000 },
+  'disused:shop': { _score: -100000 },
+  'disused:amenity': { _score: -100000 },
+  'disused:railway': { _score: -100000 },
+  'disused:leisure': { _score: -100000 },
+  // https://wiki.openstreetmap.org/wiki/Key:abandoned:
+  abandoned: { _score: -100000 },
+  'abandoned:shop': { _score: -100000 },
+  'abandoned:amenity': {
+    // note: some places such as 'Angkor Wat' are tagged 'abandoned:amenity=place_of_worship'.
+    // we use a positive integer to negate the effects of the base _score below (zeroing it out).
+    place_of_worship: { _score: +100000 },
+    _score: -100000
+  },
+  'abandoned:railway': { _score: -100000 },
+  'abandoned:leisure': { _score: -100000 },
+
+  // types of public amenities
+  amenity: {
+    disused: { _score: -100000 },
+    college: { _score: 2000 },
+    library: { _score: 2000 },
+    school: { _score: 1000 },
+    university: { _score: 2000 },
+    bank: { _score: 1000 },
+    clinic: { _score: 1000 },
+    dentist: { _score: 1000 },
+    doctors: { _score: 1000 },
+    hospital: { _score: 2000 },
+    nursing_home: { _score: 1000 },
+    pharmacy: { _score: 1000 },
+    social_facility: { _score: 1000 },
+    veterinary: { _score: 1000 },
+    community_centre: { _score: 1000 },
+    music_venue: { _score: 1000 },
+    nightclub: { _score: 1000 },
+    planetarium: { _score: 1000 },
+    social_centre: { _score: 1000 },
+    theatre: { _score: 1000 },
+    courthouse: { _score: 1000 },
+    coworking_space: { _score: 1000 },
+    dojo: { _score: 1000 },
+    embassy: { _score: 1000 },
+    ferry_terminal: { _score: 2000 },
+    fire_station: { _score: 1000 },
+    marketplace: { _score: 1000 },
+    place_of_worship: { _score: 1000 },
+    police: { _score: 1000 },
+    post_office: { _score: 1000 },
+    prison: { _score: 1000 },
+    public_bath: { _score: 1000 },
+    townhall: { _score: 1000 }
+  },
+
+  // transportation
+  aerodrome: {
+    international: { _score: 10000 },
+    regional: { _score: 5000 }
+  },
+  iata: {
+    _score: 5000,
+    none: { _score: -5000 }
+  },
+  railway: {
+    station: { _score: 2000 },
+    subway_entrance: { _score: 2000 },
+  },
+  public_transport: {
+    station: { _score: 2000 }
+    // no scoring boost for `public_transport:*`, as many unimportant records have other tags
+  },
+
+  // contact information
+  website: { _score: 200 },
+  phone: { _score: 200 },
+  'contact:website': { _score: 200 },
+  'contact:email': { _score: 200 },
+  'contact:phone': { _score: 200 },
+  'contact:fax': { _score: 200 },
+
+  // social media
+  'contact:foursquare': { _score: 200 },
+  'contact:facebook': { _score: 200 },
+  'contact:linkedin': { _score: 200 },
+  'contact:instagram': { _score: 200 },
+  'contact:skype': { _score: 200 },
+  'contact:flickr': { _score: 200 },
+  'contact:youtube': { _score: 200 },
+};
+
+module.exports = mapping;

--- a/stream/category_mapper.js
+++ b/stream/category_mapper.js
@@ -13,8 +13,9 @@
   @see: ./config/category_map.js
 **/
 
-var through = require('through2');
-var peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
+const _ = require('lodash');
+const through = require('through2');
+const peliasLogger = require('pelias-logger').get('openstreetmap');
 
 module.exports = function( mapping ){
 
@@ -34,24 +35,24 @@ module.exports = function( mapping ){
       }
 
       // iterate over mapping
-      for( var key in mapping ){
+      _.each(mapping, (osmTagValues, osmTagKey) => {
 
         // check each mapping key against document tags
-        if( !tags.hasOwnProperty( key ) ){ continue; }
+        if( !tags.hasOwnProperty( osmTagKey ) ){ return; }
 
         // handle mapping wildcards
-        if( mapping[key].hasOwnProperty('*') ){
-          addCategories( doc, mapping[key]['*'] );
+        if( osmTagValues.hasOwnProperty('*') ){
+          addCategories( doc, osmTagValues['*'] );
         }
 
         // handle regular features
-        for( var feature in mapping[key] ){
-          if( '*' === feature ){ continue; }
-          if( tags[key] === feature ){
-            addCategories( doc, mapping[key][feature] );
+        _.each(osmTagValues, (categories, osmTagValue) => {
+          if( '*' === osmTagValue ){ return; }
+          if( tags[osmTagKey] === osmTagValue ){
+            addCategories( doc, categories );
           }
-        }
-      }
+        });
+      });
     }
 
     catch( e ){

--- a/stream/popularity_mapper.js
+++ b/stream/popularity_mapper.js
@@ -8,161 +8,11 @@
   Feel free to make changes to this mapping file!
 **/
 
+const _ = require('lodash');
 const through = require('through2');
 const peliasLogger = require('pelias-logger').get('openstreetmap');
 const peliasConfig = require('pelias-config').generate();
-
-const config = {
-  // https://taginfo.openstreetmap.org/keys/importance
-  importance: {
-    international: { _score: 50000 },
-    national: { _score: 10000 },
-    regional: { _score: 5000 },
-    urban: { _score: 1000 },
-    suburban: { _score: 500 },
-    local: { _score: 100 },
-  },
-
-  // concordances
-  wikipedia: { _score: 3000 },
-  wikidata: { _score: 3000 },
-
-  // properties found on major landmarks &
-  // public buildings.
-  architect: { _score: 5000 },
-  heritage: { _score: 5000 },
-  'heritage:operator': { _score: 2000 },
-  historic: {
-    building: { _score: 5000 },
-    church: { _score: 5000 },
-    heritage: { _score: 7000 },
-    _score: 1000,
-  },
-  building: {
-    colour: { _score: 2000 },
-    material: { _score: 2000 },
-    supermarket: { _score: 2000 },
-    civic: { _score: 2000 },
-    government: { _score: 2000 },
-    hospital: { _score: 2000 },
-    train_station: { _score: 5000 },
-    transportation: { _score: 2000 },
-    university: { _score: 2000 },
-    public: { _score: 2000 },
-    sports_hall: { _score: 2000 },
-    historic: { _score: 5000 },
-  },
-  height: { _score: 2000 },
-  start_date: { _score: 2000 },
-  opening_date: { _score: 2000 },
-
-  // properties found on tourist attractions
-  tourism: {
-    visitors: { _score: 2000 },
-    aquarium: { _score: 2000 },
-    attraction: { _score: 1000 },
-    museum: { _score: 2000 },
-    theme_park: { _score: 2000 },
-    zoo: { _score: 2000 },
-    _score: 1000
-  },
-  museum: { _score: 2000 },
-  museum_type: { _score: 2000 },
-  opening_hours: { _score: 1000 },
-  operator: { _score: 1000 },
-  fee: { _score: 2000 },
-
-  // closed and abandoned places
-  // https://wiki.openstreetmap.org/wiki/Key:disused:
-  disused: { _score: -100000 },
-  'disused:shop': { _score: -100000 },
-  'disused:amenity': { _score: -100000 },
-  'disused:railway': { _score: -100000 },
-  'disused:leisure': { _score: -100000 },
-  // https://wiki.openstreetmap.org/wiki/Key:abandoned:
-  abandoned: { _score: -100000 },
-  'abandoned:shop': { _score: -100000 },
-  'abandoned:amenity': {
-    // note: some places such as 'Angkor Wat' are tagged 'abandoned:amenity=place_of_worship'.
-    // we use a positive integer to negate the effects of the base _score below (zeroing it out).
-    place_of_worship: { _score: +100000 },
-    _score: -100000
-  },
-  'abandoned:railway': { _score: -100000 },
-  'abandoned:leisure': { _score: -100000 },
-
-  // types of public amenities
-  amenity: {
-    disused: { _score: -100000 },
-    college: { _score: 2000 },
-    library: { _score: 2000 },
-    school: { _score: 1000 },
-    university: { _score: 2000 },
-    bank: { _score: 1000 },
-    clinic: { _score: 1000 },
-    dentist: { _score: 1000 },
-    doctors: { _score: 1000 },
-    hospital: { _score: 2000 },
-    nursing_home: { _score: 1000 },
-    pharmacy: { _score: 1000 },
-    social_facility: { _score: 1000 },
-    veterinary: { _score: 1000 },
-    community_centre: { _score: 1000 },
-    music_venue: { _score: 1000 },
-    nightclub: { _score: 1000 },
-    planetarium: { _score: 1000 },
-    social_centre: { _score: 1000 },
-    theatre: { _score: 1000 },
-    courthouse: { _score: 1000 },
-    coworking_space: { _score: 1000 },
-    dojo: { _score: 1000 },
-    embassy: { _score: 1000 },
-    ferry_terminal: { _score: 2000 },
-    fire_station: { _score: 1000 },
-    marketplace: { _score: 1000 },
-    place_of_worship: { _score: 1000 },
-    police: { _score: 1000 },
-    post_office: { _score: 1000 },
-    prison: { _score: 1000 },
-    public_bath: { _score: 1000 },
-    townhall: { _score: 1000 }
-  },
-
-  // transportation
-  aerodrome: {
-    international: { _score: 10000 },
-    regional: { _score: 5000 }
-  },
-  iata: {
-    _score: 5000,
-    none: { _score: -5000 }
-  },
-  railway: {
-    station: { _score: 2000 },
-    subway_entrance: { _score: 2000 },
-  },
-  public_transport: {
-    station: { _score: 2000 }
-    // no scoring boost for `public_transport:*`, as many unimportant records have other tags
-  },
-
-  // contact information
-  website: { _score: 200 },
-  phone: { _score: 200 },
-  'contact:website': { _score: 200 },
-  'contact:email': { _score: 200 },
-  'contact:phone': { _score: 200 },
-  'contact:fax': { _score: 200 },
-
-  // social media
-  'contact:foursquare': { _score: 200 },
-  'contact:facebook': { _score: 200 },
-  'contact:linkedin': { _score: 200 },
-  'contact:instagram': { _score: 200 },
-  'contact:skype': { _score: 200 },
-  'contact:flickr': { _score: 200 },
-  'contact:youtube': { _score: 200 },
-};
+const mapping = require('../config/popularity_map');
 
 module.exports = function(){
 
@@ -185,22 +35,22 @@ module.exports = function(){
       let popularity = doc.getPopularity() || 0;
 
       // apply scores from config
-      for( let tag in config ){
-        if( tags.hasOwnProperty( tag ) ){
+      _.each(mapping, (osmTagScores, osmTagKey) => {
+        if( tags.hasOwnProperty( osmTagKey ) ){
           // global score for the tag
-          if( config[tag]._score ){
-            popularity += config[tag]._score;
+          if( osmTagScores._score ){
+            popularity += osmTagScores._score;
           }
           // individual scores for specific values
-          for( let value in config[tag] ){
-            if( value === '_score' ){ continue; }
-            if( !config[tag][value]._score ){ continue; }
-            if (tags[tag].trim().toLowerCase() === value ){
-              popularity += config[tag][value]._score;
+          _.each(osmTagScores, (osmSubTagScores, osmTagValue) => {
+            if( osmTagValue === '_score' ){ return; }
+            if( !osmSubTagScores._score ){ return; }
+            if (_.get(tags, osmTagKey, '').trim().toLowerCase() === osmTagValue ){
+              popularity += osmSubTagScores._score;
             }
-          }
+          });
         }
-      }
+      });
 
       // addresses with a popularity score GTE 10000 receieve
       // a popularity of 1000, all others get a popularity of 0.

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -45,7 +45,7 @@ module.exports = function(){
         }
 
         // Map name data from our name mapping schema
-        else if( tag in NAME_SCHEMA ){
+        else if( _.has(NAME_SCHEMA, tag) ){
           var val2 = trim( tags[tag] );
           if( val2 ){
             if( tag === NAME_SCHEMA._primary ){
@@ -59,7 +59,7 @@ module.exports = function(){
         }
 
         // Map address data from our address mapping schema
-        else if( tag in ADDRESS_SCHEMA ){
+        else if( _.has(ADDRESS_SCHEMA, tag) ){
           var val3 = trim( tags[tag] );
           if( val3 ){
             doc.setAddress( ADDRESS_SCHEMA[tag], val3 );

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -32,40 +32,40 @@ module.exports = function(){
 
       // Unfortunately we need to iterate over every tag,
       // so we only do the iteration once to save CPU.
-      for( var tag in tags ){
+      _.each(tags, (value, key) => {
 
         // Map localized names which begin with 'name:'
         // @ref: http://wiki.openstreetmap.org/wiki/Namespace#Language_code_suffix
-        var suffix = getNameSuffix( tag );
+        var suffix = getNameSuffix( key );
         if( suffix ){
-          var val1 = trim( tags[tag] );
+          var val1 = trim( value );
           if( val1 ){
             doc.setName( suffix, val1 );
           }
         }
 
         // Map name data from our name mapping schema
-        else if( _.has(NAME_SCHEMA, tag) ){
-          var val2 = trim( tags[tag] );
+        else if( _.has(NAME_SCHEMA, key) ){
+          var val2 = trim( value );
           if( val2 ){
-            if( tag === NAME_SCHEMA._primary ){
-              doc.setName( NAME_SCHEMA[tag], val2 );
-            } else if ( 'default' === NAME_SCHEMA[tag] ) {
-              doc.setNameAlias( NAME_SCHEMA[tag], val2 );
+            if( key === NAME_SCHEMA._primary ){
+              doc.setName( NAME_SCHEMA[key], val2 );
+            } else if ( 'default' === NAME_SCHEMA[key] ) {
+              doc.setNameAlias( NAME_SCHEMA[key], val2 );
             } else {
-              doc.setName( NAME_SCHEMA[tag], val2 );
+              doc.setName( NAME_SCHEMA[key], val2 );
             }
           }
         }
 
         // Map address data from our address mapping schema
-        else if( _.has(ADDRESS_SCHEMA, tag) ){
-          var val3 = trim( tags[tag] );
+        else if( _.has(ADDRESS_SCHEMA, key) ){
+          var val3 = trim( value );
           if( val3 ){
-            doc.setAddress( ADDRESS_SCHEMA[tag], val3 );
+            doc.setAddress( ADDRESS_SCHEMA[key], val3 );
           }
         }
-      }
+      });
 
       // Handle the case where no default name was set but there were
       // other names which we could use as the default.

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -420,6 +420,25 @@ module.exports.tests.newline_in_value = function(test, common) {
   });
 };
 
+// ======================= misc ========================
+
+// Tags with a key which matches a JS reserved word should not cause errors
+// https://github.com/pelias/openstreetmap/issues/557
+module.exports.tests.skip_inherited_enumerable_properties = function(test, common) {
+  var doc = new Document('a','b',1);
+  doc.setMeta('tags', { 'constructor': 'example' });
+  test('skip_inherited_enumerable_properties', function(t) {
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.false(doc.name.hasOwnProperty('function Object() { [native code] }'));
+      t.false(Object.keys(doc.name).length, 'empty');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {


### PR DESCRIPTION
I was interested in https://github.com/pelias/openstreetmap/issues/557, it seems that we are using the [in operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) / [for ... in](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in) syntax which iterates over all properties "including inherited enumerable properties".

A quick `git grep` shows other usages of that syntax in this lib which might need attention too.

closes https://github.com/pelias/openstreetmap/issues/557