### PR TITLE
tag_mapper: contract english diagonals for street addresses

### DIFF
--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -62,7 +62,8 @@ module.exports = function(){
         else if( _.has(ADDRESS_SCHEMA, key) ){
           var val3 = trim( value );
           if( val3 ){
-            doc.setAddress( ADDRESS_SCHEMA[key], val3 );
+            let label = ADDRESS_SCHEMA[key];
+            doc.setAddress(label, normalizeAddressField(label, val3));
           }
         }
       });
@@ -148,4 +149,21 @@ function getNameSuffix( tag ){
   }
 
   return suffix;
+}
+
+// apply some very basic normalization
+// note: in the future we should consider doing something more advanced like:
+// https://github.com/pelias/openaddresses/pull/477
+function normalizeAddressField(key, value) {
+  if (key === 'street') {
+
+    // contract English diagonals
+    value = value
+      .replace(/\b(northwest)\b/i, 'NW')
+      .replace(/\b(northeast)\b/i, 'NE')
+      .replace(/\b(southwest)\b/i, 'SW')
+      .replace(/\b(southeast)\b/i, 'SE');
+  }
+
+  return value;
 }

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -302,6 +302,55 @@ module.exports.tests.karlsruhe_schema = function(test, common) {
   });
 };
 
+// ======================== address normalization =========================
+
+module.exports.tests.contract_directionals = (test, common) => {
+  test('norm - contract directionals at end', (t) => {
+    var doc = new Document('a', 'b', 1);
+    doc.setMeta('tags', { 'addr:street': 'Foo Street Southwest' });
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.equal(doc.getAddress('street'), 'Foo Street SW', 'contracted');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+  test('norm - contract directionals at start', (t) => {
+    var doc = new Document('a', 'b', 1);
+    doc.setMeta('tags', { 'addr:street': 'Southwest Foo Street' });
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.equal(doc.getAddress('street'), 'SW Foo Street', 'contracted');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+  test('norm - requires trailing word break', (t) => {
+    var doc = new Document('a', 'b', 1);
+    doc.setMeta('tags', { 'addr:street': 'Foo Street Southwestern' });
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.equal(doc.getAddress('street'), 'Foo Street Southwestern', 'no-op');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+  test('norm - requires leading word break', (t) => {
+    var doc = new Document('a', 'b', 1);
+    doc.setMeta('tags', { 'addr:street': 'OurSouthwest Foo Street' });
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.equal(doc.getAddress('street'), 'OurSouthwest Foo Street', 'no-op');
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
 // ======================== data cleansing =========================
 
 module.exports.tests.trim_junk = function(test, common) {


### PR DESCRIPTION
Some addresses are failing to deduplicate because of minor differences in the expansion/contraction of diagonals:

<img width="598" alt="Screenshot 2021-08-20 at 12 45 00" src="https://user-images.githubusercontent.com/738069/130222062-5c9fbb28-58fa-4d6c-b5c7-2a58bb060643.png">

This PR is very basic, it simply replaces the expanded form of these diagonals (in English only) where found in a street field.

We have a more advanced strategy for `openaddresses` in https://github.com/pelias/openaddresses/pull/477 which I'd like to port over to this repo too at some point, one difficulty with that is detecting the language appropriately.

This PR is a very simple fix in the interim.

The `pelias/schema` codebase has [synonym mappings](https://github.com/pelias/schema/blob/7eca249ea3657f08d4e758c5351a18b3ec79df8f/synonyms/directionals/en.txt#L16) which will allow matching to work in both forms.
