### PR TITLE
Remove 'merge' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "iso-639-3": "^1.0.0",
     "joi": "^14.0.0",
     "lodash": "^4.17.4",
-    "merge": "^1.2.0",
     "pbf2json": "^6.9.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^4.12.0",

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -6,12 +6,11 @@
 
 const _ = require('lodash');
 const through = require('through2');
-const merge = require('merge');
 const peliasLogger = require('pelias-logger').get('openstreetmap');
 
 var LOCALIZED_NAME_KEYS = require('../config/localized_name_keys');
 var NAME_SCHEMA = require('../schema/name_osm');
-var ADDRESS_SCHEMA = merge( true, false,
+var ADDRESS_SCHEMA = _.merge( {},
   require('../schema/address_tiger'),
   require('../schema/address_osm'),
   require('../schema/address_naptan'),


### PR DESCRIPTION
This package has an open [security vulnerability](https://github.com/advisories/GHSA-7wpw-2hjm-89gp), but can easily be replaced by the Lodash [_.merge](https://docs-lodash.com/v4/merge/) function.