### PR TITLE
Add large test fixtures to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 .git
 node_modules
+
+# large test fixtures
+test/*.pbf
+test/fixtures/combined_vancouver_queens.json


### PR DESCRIPTION
While running some other analysis on our docker images I noticed that the Docker image for OSM will include the ~30MB of PBF files and test fixtures we use in our end-to-end tests.

Currently, we don't run anything but the unit tests during the Docker image build, so these files are never used.

Since it will save quite a bit of space and reduce network usage every time someone downloads a new copy of the OSM Docker image, removing them seems like the right call.