### PR TITLE
Properly process alt_name tag when there are multiple entries separated by semicolon

### DIFF
--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -50,7 +50,16 @@ module.exports = function(){
             if( key === NAME_SCHEMA._primary ){
               doc.setName( NAME_SCHEMA[key], val2 );
             } else if ( 'default' === NAME_SCHEMA[key] ) {
-              doc.setNameAlias( NAME_SCHEMA[key], val2 );
+              // `alt_name` may contain multiple names separated by semicolons 
+              // (see https://wiki.openstreetmap.org/wiki/Key:alt_name#Examples)
+              if (key === 'alt_name') {
+                const altNames = val2.split(';');
+                altNames.forEach((altName) => {
+                  doc.setNameAlias( NAME_SCHEMA[key], altName );
+                });
+              } else {
+                doc.setNameAlias( NAME_SCHEMA[key], val2 );
+              }
             } else {
               doc.setName( NAME_SCHEMA[key], val2 );
             }

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -108,6 +108,33 @@ module.exports.tests.osm_names = function(test, common) {
       t.end(); // test will fail if not called (or called twice).
       next();
     }));
+    
+    stream.write(doc);
+  });
+
+  test('maps - name aliases - multiple alt_names', function(t) {
+    var doc = new Document('a','b',1);
+    doc.setMeta('tags', {
+      loc_name: 'loc_name',
+      nat_name: 'nat_name',
+      int_name: 'int_name',
+      name: 'name',
+      alt_name: 'alt_name;alt_name2',
+      official_name: 'official_name',
+      old_name: 'old_name',
+      reg_name: 'reg_name',
+      short_name: 'short_name',
+      sorting_name: 'sorting_name'
+    });
+    var stream = mapper();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal(doc.getName('default'), 'name', 'correctly mapped');
+      t.deepEqual(doc.getNameAliases('default'), ['loc_name','alt_name','alt_name2','short_name'], 'correctly mapped');
+
+      t.end(); // test will fail if not called (or called twice).
+      next();
+    }));
+    
     stream.write(doc);
   });
 };

--- a/test/stream/tag_mapper.js
+++ b/test/stream/tag_mapper.js
@@ -119,7 +119,7 @@ module.exports.tests.osm_names = function(test, common) {
       nat_name: 'nat_name',
       int_name: 'int_name',
       name: 'name',
-      alt_name: 'alt_name;alt_name2',
+      alt_name: 'alt_name;alt_name2;alt_name3',
       official_name: 'official_name',
       old_name: 'old_name',
       reg_name: 'reg_name',
@@ -129,7 +129,7 @@ module.exports.tests.osm_names = function(test, common) {
     var stream = mapper();
     stream.pipe( through.obj( function( doc, enc, next ){
       t.equal(doc.getName('default'), 'name', 'correctly mapped');
-      t.deepEqual(doc.getNameAliases('default'), ['loc_name','alt_name','alt_name2','short_name'], 'correctly mapped');
+      t.deepEqual(doc.getNameAliases('default'), ['loc_name','alt_name','alt_name2','alt_name3','short_name'], 'correctly mapped');
 
       t.end(); // test will fail if not called (or called twice).
       next();


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

OSM's alt_name tag may contain multiple entries which are separated by semicolon (`;`) that's why I propose to split by it and use each entry as separate alias name. 
See: https://wiki.openstreetmap.org/wiki/Key:alt_name#Examples
Example: https://www.openstreetmap.org/way/31151623

<img width="331" alt="Screenshot 2024-11-29 at 14 49 26" src="https://github.com/user-attachments/assets/35d2831f-e131-4746-8f80-ce472a13f7c3">


<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
Just additional `split` call for `alt_name` tags :) 
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

---
#### Here's how others can test the changes :eyes:
I added new test (which is almost copy-paste of one of existing ones though, but couldn't come up with better solution)
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
