### PR TITLE
support semi-colon delimited names

### DIFF
--- a/schema/address_karlsruhe.js
+++ b/schema/address_karlsruhe.js
@@ -10,7 +10,7 @@
   @ref: http://wiki.openstreetmap.org/wiki/Karlsruhe_Schema
 **/
 
-var KARLSRUHE_SCHEMA = {
+const KARLSRUHE_SCHEMA = {
   'addr:housename':     'name',
   'addr:housenumber':   'number',
   'addr:street':        'street',

--- a/schema/address_naptan.js
+++ b/schema/address_naptan.js
@@ -10,7 +10,7 @@
   @ref: http://wiki.openstreetmap.org/wiki/NaPTAN
 **/
 
-var NAPTAN_SCHEMA = {
+const NAPTAN_SCHEMA = {
   'naptan:Street': 'street'
 };
 

--- a/schema/address_osm.js
+++ b/schema/address_osm.js
@@ -10,7 +10,7 @@
   @ref: http://wiki.openstreetmap.org/wiki/Key:postal_code
 **/
 
-var OSM_SCHEMA = {
+const OSM_SCHEMA = {
   'postal_code': 'zip'
 };
 

--- a/schema/address_tiger.js
+++ b/schema/address_tiger.js
@@ -10,7 +10,7 @@
   @ref: http://wiki.openstreetmap.org/wiki/TIGER_to_OSM_Attribute_Map
 **/
 
-var TIGER_SCHEMA = {
+const TIGER_SCHEMA = {
   'tiger:zip_left': 'zip',
   'tiger:zip_right': 'zip'
 };

--- a/schema/name_osm.js
+++ b/schema/name_osm.js
@@ -14,16 +14,13 @@
   When multiple keys have the value 'default' then they are considered
   as aliases of the default field.
 
-  The '_primary' property defined below defines which of those aliases
-  is considered the 'primary default name' for label generation.
-
   No values other than 'default' should be specified more than once.
 
   @ref: http://wiki.openstreetmap.org/wiki/Key:name
   @ref: http://wiki.openstreetmap.org/wiki/Names
 **/
 
-var OSM_NAMING_SCHEMA = {
+const OSM_NAMING_SCHEMA = {
   'name':             'default',
   'loc_name':         'default',
   'alt_name':         'default',
@@ -37,15 +34,5 @@ var OSM_NAMING_SCHEMA = {
   // 'reg_name':         'regional',
   // 'sorting_name':     'sorting'
 };
-
-// this property is considered the 'primary name'
-// for label generation, the others are considered
-// secondary or 'aliases'.
-Object.defineProperty(OSM_NAMING_SCHEMA, '_primary', {
-  value: 'name',
-  enumerable: false,
-  configurable: false,
-  writable: false
-});
 
 module.exports = OSM_NAMING_SCHEMA;

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -47,7 +47,7 @@ module.exports = function(){
         else if( _.has(NAME_SCHEMA, key) ){
           const nameValue = trim( value );
           if( nameValue ){
-            if( key === NAME_SCHEMA._primary ){
+            if( 'name' === key ){
               doc.setName( NAME_SCHEMA[key], nameValue );
             } else if ( 'default' === NAME_SCHEMA[key] ) {
               doc.setNameAlias( NAME_SCHEMA[key], nameValue );

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -7,6 +7,7 @@
 const _ = require('lodash');
 const through = require('through2');
 const peliasLogger = require('pelias-logger').get('openstreetmap');
+const parseSemicolonDelimitedValues = require('../util/parseSemicolonDelimitedValues');
 
 const LOCALIZED_NAME_KEYS = require('../config/localized_name_keys');
 const NAME_SCHEMA = require('../schema/name_osm');
@@ -37,29 +38,34 @@ module.exports = function(){
         // @ref: http://wiki.openstreetmap.org/wiki/Namespace#Language_code_suffix
         const langCode = getNameSuffix( key );
         if( langCode ){
-          const langValue = trim( value );
-          if( langValue ){
-            doc.setName( langCode, langValue );
-          }
+          const langValues = parseSemicolonDelimitedValues( value );
+          langValues.forEach(( langValue, i ) => {
+            if ( i === 0 ) {
+              doc.setName( langCode, langValue );
+            } else {
+              doc.setNameAlias( langCode, langValue );
+            }
+          });
         }
 
         // Map name data from our name mapping schema
         else if( _.has(NAME_SCHEMA, key) ){
-          const nameValue = trim( value );
-          if( nameValue ){
-            if( 'name' === key ){
-              doc.setName( NAME_SCHEMA[key], nameValue );
-            } else if ( 'default' === NAME_SCHEMA[key] ) {
-              doc.setNameAlias( NAME_SCHEMA[key], nameValue );
-            } else {
-              doc.setName( NAME_SCHEMA[key], nameValue );
+          const nameValues = parseSemicolonDelimitedValues( cleanString( value ) );
+          nameValues.forEach(( nameValue, i ) => {
+            // For the primary name key 'name', ensure it is the first value
+            if( 'name' === key && i === 0 ){
+              doc.setName(NAME_SCHEMA[key], nameValue);
+              return;
             }
-          }
+
+            // Otherwise set as an alias
+            doc.setNameAlias( NAME_SCHEMA[key], nameValue );
+          });
         }
 
         // Map address data from our address mapping schema
         else if( _.has(ADDRESS_SCHEMA, key) ){
-          const addrValue = trim( value );
+          const addrValue = cleanString( value );
           if( addrValue ){
             const label = ADDRESS_SCHEMA[key];
             doc.setAddress(label, normalizeAddressField(label, addrValue));
@@ -71,16 +77,17 @@ module.exports = function(){
       // other names which we could use as the default.
       if( !doc.getName('default') ){
 
-        const defaultName =
-          _.get(tags, 'official_name') ||
-          _.get(tags, 'int_name') ||
-          _.get(tags, 'nat_name') ||
-          _.get(tags, 'reg_name') ||
-          doc.getName('en');
+        const defaultName = [
+          ...parseSemicolonDelimitedValues(_.get(tags, 'official_name')),
+          ...parseSemicolonDelimitedValues(_.get(tags, 'int_name')),
+          ...parseSemicolonDelimitedValues(_.get(tags, 'nat_name')),
+          ...parseSemicolonDelimitedValues(_.get(tags, 'reg_name')),
+          ...parseSemicolonDelimitedValues(doc.getName('en'))
+        ].filter(Boolean);
 
         // use one of the preferred name tags listed above
-        if ( defaultName ){
-          doc.setName('default', defaultName);
+        if ( defaultName.length ){
+          doc.setName('default', defaultName[0]);
         }
 
         // else try to use an available two-letter language name tag
@@ -101,7 +108,7 @@ module.exports = function(){
       // Import airport codes as aliases
       if( tags.hasOwnProperty('aerodrome') || tags.hasOwnProperty('aeroway') ){
         if( tags.hasOwnProperty('iata') ){
-          const iata = trim( tags.iata );
+          const iata = cleanString( tags.iata );
           if( iata ){
             doc.setNameAlias( 'default', iata );
             doc.setNameAlias( 'default', `${iata} Airport` );
@@ -127,7 +134,7 @@ module.exports = function(){
 };
 
 // Clean string of leading/trailing junk chars
-function trim( str ){
+function cleanString( str ){
   return _.trim( str, '#$%^*<>-=_{};:",./?\t\n\' ' );
 }
 

--- a/stream/tag_mapper.js
+++ b/stream/tag_mapper.js
@@ -8,9 +8,9 @@ const _ = require('lodash');
 const through = require('through2');
 const peliasLogger = require('pelias-logger').get('openstreetmap');
 
-var LOCALIZED_NAME_KEYS = require('../config/localized_name_keys');
-var NAME_SCHEMA = require('../schema/name_osm');
-var ADDRESS_SCHEMA = _.merge( {},
+const LOCALIZED_NAME_KEYS = require('../config/localized_name_keys');
+const NAME_SCHEMA = require('../schema/name_osm');
+const ADDRESS_SCHEMA = _.merge( {},
   require('../schema/address_tiger'),
   require('../schema/address_osm'),
   require('../schema/address_naptan'),
@@ -19,7 +19,7 @@ var ADDRESS_SCHEMA = _.merge( {},
 
 module.exports = function(){
 
-  var stream = through.obj( function( doc, enc, next ) {
+  const stream = through.obj( function( doc, enc, next ) {
 
     try {
 
@@ -35,34 +35,34 @@ module.exports = function(){
 
         // Map localized names which begin with 'name:'
         // @ref: http://wiki.openstreetmap.org/wiki/Namespace#Language_code_suffix
-        var suffix = getNameSuffix( key );
-        if( suffix ){
-          var val1 = trim( value );
-          if( val1 ){
-            doc.setName( suffix, val1 );
+        const langCode = getNameSuffix( key );
+        if( langCode ){
+          const langValue = trim( value );
+          if( langValue ){
+            doc.setName( langCode, langValue );
           }
         }
 
         // Map name data from our name mapping schema
         else if( _.has(NAME_SCHEMA, key) ){
-          var val2 = trim( value );
-          if( val2 ){
+          const nameValue = trim( value );
+          if( nameValue ){
             if( key === NAME_SCHEMA._primary ){
-              doc.setName( NAME_SCHEMA[key], val2 );
+              doc.setName( NAME_SCHEMA[key], nameValue );
             } else if ( 'default' === NAME_SCHEMA[key] ) {
-              doc.setNameAlias( NAME_SCHEMA[key], val2 );
+              doc.setNameAlias( NAME_SCHEMA[key], nameValue );
             } else {
-              doc.setName( NAME_SCHEMA[key], val2 );
+              doc.setName( NAME_SCHEMA[key], nameValue );
             }
           }
         }
 
         // Map address data from our address mapping schema
         else if( _.has(ADDRESS_SCHEMA, key) ){
-          var val3 = trim( value );
-          if( val3 ){
-            let label = ADDRESS_SCHEMA[key];
-            doc.setAddress(label, normalizeAddressField(label, val3));
+          const addrValue = trim( value );
+          if( addrValue ){
+            const label = ADDRESS_SCHEMA[key];
+            doc.setAddress(label, normalizeAddressField(label, addrValue));
           }
         }
       });
@@ -71,7 +71,7 @@ module.exports = function(){
       // other names which we could use as the default.
       if( !doc.getName('default') ){
 
-        var defaultName =
+        const defaultName =
           _.get(tags, 'official_name') ||
           _.get(tags, 'int_name') ||
           _.get(tags, 'nat_name') ||
@@ -85,7 +85,7 @@ module.exports = function(){
 
         // else try to use an available two-letter language name tag
         else {
-          var keys = Object.keys(doc.name).filter(n => n.length === 2);
+          const keys = Object.keys(doc.name).filter(n => n.length === 2);
 
           // unambiguous (there is only a single two-letter name tag)
           if ( keys.length === 1 ){
@@ -101,7 +101,7 @@ module.exports = function(){
       // Import airport codes as aliases
       if( tags.hasOwnProperty('aerodrome') || tags.hasOwnProperty('aeroway') ){
         if( tags.hasOwnProperty('iata') ){
-          var iata = trim( tags.iata );
+          const iata = trim( tags.iata );
           if( iata ){
             doc.setNameAlias( 'default', iata );
             doc.setNameAlias( 'default', `${iata} Airport` );

--- a/test/run.js
+++ b/test/run.js
@@ -17,7 +17,8 @@ var tests = [
   require('./stream/pbf'),
   require('./stream/stats'),
   require('./stream/tag_mapper'),
-  require('./stream/addresses_without_street')
+  require('./stream/addresses_without_street'),
+  require('./util/parseSemicolonDelimitedValues')
 ];
 
 tests.map(function(t) {

--- a/test/util/parseSemicolonDelimitedValues.js
+++ b/test/util/parseSemicolonDelimitedValues.js
@@ -1,0 +1,38 @@
+const parseSemicolonDelimitedValues = require('../../util/parseSemicolonDelimitedValues');
+
+module.exports.tests = {};
+
+// test exports
+module.exports.tests.smoke = function (test, common) {
+  test('interface', t => {
+    t.equal(typeof parseSemicolonDelimitedValues, 'function', 'function');
+    t.end();
+  });
+  test('parse - invalid', t => {
+    t.deepEqual(parseSemicolonDelimitedValues(1), []);
+    t.deepEqual(parseSemicolonDelimitedValues(['a']), []);
+    t.deepEqual(parseSemicolonDelimitedValues([{'a': 'b'}]), []);
+    t.deepEqual(parseSemicolonDelimitedValues(undefined), []);
+    t.deepEqual(parseSemicolonDelimitedValues(null), []);
+    t.deepEqual(parseSemicolonDelimitedValues(''), []);
+    t.end();
+  });
+  test('parse - examples', t => {
+    t.deepEqual(parseSemicolonDelimitedValues(''), []);
+    t.deepEqual(parseSemicolonDelimitedValues(' '), []);
+    t.deepEqual(parseSemicolonDelimitedValues(' ;; ; ; ; ; ;; ; ;; '), []);
+    t.deepEqual(parseSemicolonDelimitedValues(' a; b ;;; ; '), ['a', 'b']);
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('parseSemicolonDelimitedValues: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/util/parseSemicolonDelimitedValues.js
+++ b/util/parseSemicolonDelimitedValues.js
@@ -1,0 +1,9 @@
+const _ = require('lodash');
+
+// Split multi-value OSM tags into an Array
+// https://wiki.openstreetmap.org/wiki/Talk:Semi-colon_value_separator
+function parseSemicolonDelimitedValues(value) {
+  return (_.isString(value) ? value : '').split(';').map(Function.prototype.call, String.prototype.trim);
+}
+
+module.exports = parseSemicolonDelimitedValues;

--- a/util/parseSemicolonDelimitedValues.js
+++ b/util/parseSemicolonDelimitedValues.js
@@ -3,7 +3,10 @@ const _ = require('lodash');
 // Split multi-value OSM tags into an Array
 // https://wiki.openstreetmap.org/wiki/Talk:Semi-colon_value_separator
 function parseSemicolonDelimitedValues(value) {
-  return (_.isString(value) ? value : '').split(';').map(Function.prototype.call, String.prototype.trim);
+  return (_.isString(value) ? value : '')
+    .split(';')
+    .map(Function.prototype.call, String.prototype.trim)
+    .filter(Boolean);
 }
 
 module.exports = parseSemicolonDelimitedValues;

--- a/util/parseSemicolonDelimitedValues.js
+++ b/util/parseSemicolonDelimitedValues.js
@@ -5,8 +5,8 @@ const _ = require('lodash');
 function parseSemicolonDelimitedValues(value) {
   return (_.isString(value) ? value : '')
     .split(';')
-    .map(Function.prototype.call, String.prototype.trim)
-    .filter(Boolean);
+    .map(v => v.trim())
+    .filter(v => v.length);
 }
 
 module.exports = parseSemicolonDelimitedValues;


### PR DESCRIPTION
replaces https://github.com/pelias/openstreetmap/pull/581

> note: commits need to be squashed and correctly prefixed (with `feat:`) before merging.

This PR adds support for semi-colon delimited names in OSM.
see: https://wiki.openstreetmap.org/wiki/Talk:Semi-colon_value_separator

Compared to #581 I added:
- Cleaning parsed values (trimming whitespace and filtering empty strings, ie. `''` or `foo;;bar`)
- Support for semi-colon delimited names in lang fields (ie. `name:en`) as well as those in `NAME_SCHEMA`.
- Moved `parseSemicolonDelimitedValues()` function to it's own module as it's used in the `address_extractor` too.
- Removed this weird `_primary` key from `NAME_SCHEMA` which probably seemed like a good idea at the time but is unnecessarily confusing.
- Updated the code which hunts for a default name when one wasn't available, also made this semi-colon aware.
- Code modernisation & cleanup - variables were confusingly named, code was dated (using `var` instead of `const` etc.)


closes https://github.com/pelias/openstreetmap/pull/581

