### PR TITLE
Allow configuring layers via `pelias.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ The OSM importer will look for a file with a name matching this value in the con
 
 If downloading from a remote URL, the filename must match the value in `sourceURL`.
 
+#### `imports.openstreetmap.layers`
+
+This is an object you can use to define your own layers based on OSM tags. For example, if you wanted a layer `coffee` for just coffee shops you could set:
+
+```
+{
+  "imports": {
+    "openstreetmap": {
+      "layers": {
+        "coffee": {
+          "tags": [ "amenity~cafe+name" ]
+        }
+      }
+    }
+  }
+}
+```
+
 #### `imports.openstreetmap.leveldbpath`
 
 This is the directory where temporary files will be stored in order to
@@ -105,6 +123,8 @@ Defaults to `tmp`.
 #### `imports.openstreetmap.importVenues`
 
 By default, the OSM importer imports both venue records and addresses. If set to false, only address records will be imported.
+
+You can also disable venue import by setting `imports.openstreetmap.layers.venue` to an empty value.
 
 #### `imports.openstreetmap.removeDisusedVenues`
 

--- a/config/features.js
+++ b/config/features.js
@@ -1,58 +1,61 @@
 
 /**
  default list of tags to extract from the pbf file when running
- imports, organized by layer. @see: https://github.com/pelias/pbf2json for more info.
- Layer order determines classifier priority — first match wins.
- venue is listed before address so that named POIs with address tags are
- classified as venues, not addresses (address classification is handled
- downstream by address_extractor).
+ imports. @see: https://github.com/pelias/pbf2json for more info.
+
+ addressTags: extracted so address_extractor can assign the address layer downstream.
+              these are not a layer themselves — address classification is structural,
+              not tag-based.
+
+ layers: keyed by output layer name. order determines classifier priority (first match wins).
+         add custom layers here (e.g. river, protected_area) to extend the importer.
 **/
 
 module.exports = {
-  venue: {
-    tags: [
-      'amenity+name',
-      'building+name',
-      'shop+name',
-      'office+name',
-      'public_transport+name',
-      'cuisine+name',
-      'railway~station+name',
-      'railway~tram_stop+name',
-      'railway~halt+name',
-      'railway~subway_entrance+name',
-      'railway~train_station_entrance+name',
-      'highway~pedestrian+area~yes+name',
-      'place~square+name',
-      'sport+name',
-      'natural+name',
-      'tourism+name',
-      'leisure+name',
-      'historic+name',
-      'man_made+name',
-      'landuse+name',
-      'waterway+name',
-      'aerialway+name',
-      'craft+name',
-      'military+name',
-      'aeroway~terminal+name',
-      'aeroway~aerodrome+name',
-      'aeroway~helipad+name',
-      'aeroway~airstrip+name',
-      'aeroway~heliport+name',
-      'aeroway~areodrome+name',
-      'aeroway~spaceport+name',
-      'aeroway~landing_strip+name',
-      'aeroway~airfield+name',
-      'aeroway~airport+name',
-      'brand+name',
-      'healthcare+name'
-    ]
-  },
-  address: {
-    tags: [
-      'addr:housenumber+addr:street',
-      'addr:housenumber+addr:place'  // @ref https://github.com/pelias/pelias/issues/787#issuecomment-477137803
-    ]
+  addressTags: [
+    'addr:housenumber+addr:street',
+    'addr:housenumber+addr:place'  // @ref https://github.com/pelias/pelias/issues/787#issuecomment-477137803
+  ],
+  layers: {
+    venue: {
+      tags: [
+        'amenity+name',
+        'building+name',
+        'shop+name',
+        'office+name',
+        'public_transport+name',
+        'cuisine+name',
+        'railway~station+name',
+        'railway~tram_stop+name',
+        'railway~halt+name',
+        'railway~subway_entrance+name',
+        'railway~train_station_entrance+name',
+        'highway~pedestrian+area~yes+name',
+        'place~square+name',
+        'sport+name',
+        'natural+name',
+        'tourism+name',
+        'leisure+name',
+        'historic+name',
+        'man_made+name',
+        'landuse+name',
+        'waterway+name',
+        'aerialway+name',
+        'craft+name',
+        'military+name',
+        'aeroway~terminal+name',
+        'aeroway~aerodrome+name',
+        'aeroway~helipad+name',
+        'aeroway~airstrip+name',
+        'aeroway~heliport+name',
+        'aeroway~areodrome+name',
+        'aeroway~spaceport+name',
+        'aeroway~landing_strip+name',
+        'aeroway~airfield+name',
+        'aeroway~airport+name',
+        'brand+name',
+        'healthcare+name'
+      ]
+    }
   }
 };

--- a/config/features.js
+++ b/config/features.js
@@ -3,15 +3,12 @@
  default list of tags to extract from the pbf file when running
  imports, organized by layer. @see: https://github.com/pelias/pbf2json for more info.
  Layer order determines classifier priority — first match wins.
+ venue is listed before address so that named POIs with address tags are
+ classified as venues, not addresses (address classification is handled
+ downstream by address_extractor).
 **/
 
 module.exports = {
-  address: {
-    tags: [
-      'addr:housenumber+addr:street',
-      'addr:housenumber+addr:place'  // @ref https://github.com/pelias/pelias/issues/787#issuecomment-477137803
-    ]
-  },
   venue: {
     tags: [
       'amenity+name',
@@ -50,6 +47,12 @@ module.exports = {
       'aeroway~airport+name',
       'brand+name',
       'healthcare+name'
+    ]
+  },
+  address: {
+    tags: [
+      'addr:housenumber+addr:street',
+      'addr:housenumber+addr:place'  // @ref https://github.com/pelias/pelias/issues/787#issuecomment-477137803
     ]
   }
 };

--- a/config/features.js
+++ b/config/features.js
@@ -1,53 +1,55 @@
 
 /**
  default list of tags to extract from the pbf file when running
- imports. @see: https://github.com/pelias/pbf2json for more info.
+ imports, organized by layer. @see: https://github.com/pelias/pbf2json for more info.
+ Layer order determines classifier priority — first match wins.
 **/
 
-// default tags imported
-const tags = [
-  'addr:housenumber+addr:street',
-  'addr:housenumber+addr:place'  // @ref https://github.com/pelias/pelias/issues/787#issuecomment-477137803
-];
-
-// tags corresponding to venues
-const venue_tags = [
-  'amenity+name',
-  'building+name',
-  'shop+name',
-  'office+name',
-  'public_transport+name',
-  'cuisine+name',
-  'railway~station+name',
-  'railway~tram_stop+name',
-  'railway~halt+name',
-  'railway~subway_entrance+name',
-  'railway~train_station_entrance+name',
-  'highway~pedestrian+area~yes+name',
-  'place~square+name',
-  'sport+name',
-  'natural+name',
-  'tourism+name',
-  'leisure+name',
-  'historic+name',
-  'man_made+name',
-  'landuse+name',
-  'waterway+name',
-  'aerialway+name',
-  'craft+name',
-  'military+name',
-  'aeroway~terminal+name',
-  'aeroway~aerodrome+name',
-  'aeroway~helipad+name',
-  'aeroway~airstrip+name',
-  'aeroway~heliport+name',
-  'aeroway~areodrome+name',
-  'aeroway~spaceport+name',
-  'aeroway~landing_strip+name',
-  'aeroway~airfield+name',
-  'aeroway~airport+name',
-  'brand+name',
-  'healthcare+name'
-];
-
-module.exports = {tags,venue_tags};
+module.exports = {
+  address: {
+    tags: [
+      'addr:housenumber+addr:street',
+      'addr:housenumber+addr:place'  // @ref https://github.com/pelias/pelias/issues/787#issuecomment-477137803
+    ]
+  },
+  venue: {
+    tags: [
+      'amenity+name',
+      'building+name',
+      'shop+name',
+      'office+name',
+      'public_transport+name',
+      'cuisine+name',
+      'railway~station+name',
+      'railway~tram_stop+name',
+      'railway~halt+name',
+      'railway~subway_entrance+name',
+      'railway~train_station_entrance+name',
+      'highway~pedestrian+area~yes+name',
+      'place~square+name',
+      'sport+name',
+      'natural+name',
+      'tourism+name',
+      'leisure+name',
+      'historic+name',
+      'man_made+name',
+      'landuse+name',
+      'waterway+name',
+      'aerialway+name',
+      'craft+name',
+      'military+name',
+      'aeroway~terminal+name',
+      'aeroway~aerodrome+name',
+      'aeroway~helipad+name',
+      'aeroway~airstrip+name',
+      'aeroway~heliport+name',
+      'aeroway~areodrome+name',
+      'aeroway~spaceport+name',
+      'aeroway~landing_strip+name',
+      'aeroway~airfield+name',
+      'aeroway~airport+name',
+      'brand+name',
+      'healthcare+name'
+    ]
+  }
+};

--- a/schema.js
+++ b/schema.js
@@ -21,7 +21,14 @@ module.exports = Joi.object().keys({
       download: Joi.array().items(Joi.object().keys({
         sourceURL: Joi.string()
       }).requiredKeys('sourceURL').unknown(true)),
-      deduplicate: Joi.boolean()
+      deduplicate: Joi.boolean(),
+      addressTags: Joi.array().items(Joi.string()),
+      layers: Joi.object().pattern(
+        Joi.string(),
+        Joi.object().keys({
+          tags: Joi.array().items(Joi.string())
+        })
+      )
     }).requiredKeys('datapath', 'leveldbpath', 'import').unknown(true)
   }).requiredKeys('openstreetmap').unknown(true)
 }).requiredKeys('imports').unknown(true);

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -21,10 +21,9 @@ module.exports = function(){
       }
       var uniqueId = [ item.type, item.id ].join('/');
 
-      // classify the layer from OSM tags; default to 'venue' for anything that
-      // would classify as 'address' since address_extractor handles that downstream
-      var layer = classify(item.tags || {}, features);
-      if (layer === 'address') layer = 'venue';
+      // classify the layer from OSM tags; address_extractor assigns the address
+      // layer downstream — the classifier only covers named layers (venue, etc.)
+      var layer = classify(item.tags || {}, features.layers);
       var doc = new Document( 'openstreetmap', layer, uniqueId );
 
       // Set latitude / longitude

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -8,6 +8,8 @@ const through = require('through2');
 const Document = require('pelias-model').Document;
 const peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
 const _ = require('lodash');
+const features = require('../config/features');
+const { classify } = require('../util/layerClassifier');
 
 module.exports = function(){
 
@@ -19,8 +21,9 @@ module.exports = function(){
       }
       var uniqueId = [ item.type, item.id ].join('/');
 
-      // we need to assume it will be a venue and later if it turns out to be an address it will get changed
-      var doc = new Document( 'openstreetmap', 'venue', uniqueId );
+      // classify the layer from OSM tags; address_extractor will further refine address records
+      var layer = classify(item.tags || {}, features);
+      var doc = new Document( 'openstreetmap', layer, uniqueId );
 
       // Set latitude / longitude
       if( item.hasOwnProperty('lat') && item.hasOwnProperty('lon') ){

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -8,8 +8,11 @@ const through = require('through2');
 const Document = require('pelias-model').Document;
 const peliasLogger = require( 'pelias-logger' ).get( 'openstreetmap' );
 const _ = require('lodash');
-const features = require('../config/features');
+const settings = require('pelias-config').generate(require('../schema'));
+const resolveFeatures = require('../util/resolveFeatures');
 const { classify } = require('../util/layerClassifier');
+
+const { layers } = resolveFeatures(settings);
 
 module.exports = function(){
 
@@ -23,7 +26,7 @@ module.exports = function(){
 
       // classify the layer from OSM tags; address_extractor assigns the address
       // layer downstream — the classifier only covers named layers (venue, etc.)
-      var layer = classify(item.tags || {}, features.layers);
+      var layer = classify(item.tags || {}, layers);
       var doc = new Document( 'openstreetmap', layer, uniqueId );
 
       // Set latitude / longitude

--- a/stream/document_constructor.js
+++ b/stream/document_constructor.js
@@ -21,8 +21,10 @@ module.exports = function(){
       }
       var uniqueId = [ item.type, item.id ].join('/');
 
-      // classify the layer from OSM tags; address_extractor will further refine address records
+      // classify the layer from OSM tags; default to 'venue' for anything that
+      // would classify as 'address' since address_extractor handles that downstream
       var layer = classify(item.tags || {}, features);
+      if (layer === 'address') layer = 'venue';
       var doc = new Document( 'openstreetmap', layer, uniqueId );
 
       // Set latitude / longitude

--- a/stream/importPipeline.js
+++ b/stream/importPipeline.js
@@ -13,6 +13,7 @@ streams.tagMapper = require('./tag_mapper');
 streams.addressesWithoutStreet = require('./addresses_without_street');
 streams.adminLookup = require('pelias-wof-admin-lookup').create;
 streams.addressExtractor = require('./address_extractor');
+streams.venueFilter = require('./venueFilter');
 streams.categoryMapper = require('./category_mapper');
 streams.addendumMapper = require('./addendum_mapper');
 streams.popularityMapper = require('./popularity_mapper');
@@ -26,6 +27,7 @@ streams.import = function(){
     .pipe( streams.addressesWithoutStreet() )
     .pipe( streams.tagMapper() )
     .pipe( streams.addressExtractor() )
+    .pipe( streams.venueFilter() )
     .pipe( streams.blacklistStream() )
     .pipe( streams.categoryMapper( categoryDefaults ) )
     .pipe( streams.addendumMapper() )

--- a/stream/pbf.js
+++ b/stream/pbf.js
@@ -46,10 +46,10 @@ function config(opts){
   if(!opts.tags){
     // check if we import venues
     opts.importVenues = settings.imports.openstreetmap.import[0].importVenues;
-    const layers = opts.importVenues === false
-      ? Object.keys(features).filter(l => l !== 'venue')
-      : Object.keys(features);
-    opts.tags = layers.flatMap(layer => features[layer]?.tags ?? []);
+    const layerTags = opts.importVenues === false
+      ? []
+      : Object.values(features.layers).flatMap(l => l.tags ?? []);
+    opts.tags = features.addressTags.concat(layerTags);
   }
   return opts;
 }

--- a/stream/pbf.js
+++ b/stream/pbf.js
@@ -7,7 +7,7 @@
 var fs = require('fs'),
     pbf2json = require('pbf2json'),
     settings = require('pelias-config').generate(require('../schema')),
-    features = require('../config/features'),
+    resolveFeatures = require('../util/resolveFeatures'),
     path = require('path');
 
 // Create a new pbf parser stream
@@ -46,6 +46,7 @@ function config(opts){
   if(!opts.tags){
     // check if we import venues
     opts.importVenues = settings.imports.openstreetmap.import[0].importVenues;
+    const features = resolveFeatures(settings);
     const layerTags = opts.importVenues === false
       ? []
       : Object.values(features.layers).flatMap(l => l.tags ?? []);

--- a/stream/pbf.js
+++ b/stream/pbf.js
@@ -46,11 +46,10 @@ function config(opts){
   if(!opts.tags){
     // check if we import venues
     opts.importVenues = settings.imports.openstreetmap.import[0].importVenues;
-    if(opts.importVenues){
-      opts.tags = features.tags.concat(features.venue_tags);
-    } else {
-      opts.tags = features.tags;
-    }
+    const layers = opts.importVenues === false
+      ? Object.keys(features).filter(l => l !== 'venue')
+      : Object.keys(features);
+    opts.tags = layers.flatMap(layer => features[layer]?.tags ?? []);
   }
   return opts;
 }

--- a/stream/venueFilter.js
+++ b/stream/venueFilter.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * When importVenues is false, drop any record that is not in the address layer.
+ * This prevents named POIs that also have address tags from leaking through as
+ * venue records when venue import is disabled.
+ *
+ * Note: the preferred way to control which layers are imported is now to set
+ * `imports.openstreetmap.layers` in pelias.json. Setting `importVenues: false`
+ * is equivalent to `layers: {}` and is retained for backward compatibility.
+ */
+
+const through = require('through2');
+const settings = require('pelias-config').generate(require('../schema'));
+
+module.exports = function() {
+  const importVenues = settings.imports.openstreetmap.import[0].importVenues;
+
+  // passthrough when venues are enabled (default)
+  if (importVenues !== false) {
+    return through.obj();
+  }
+
+  return through.obj(function(doc, enc, next) {
+    if (doc.getLayer() === 'address') {
+      this.push(doc);
+    }
+    next();
+  });
+};

--- a/test/config/features.js
+++ b/test/config/features.js
@@ -5,70 +5,73 @@ module.exports.tests = {};
 // test exports
 module.exports.tests.interface = function(test, common) {
   test('interface: features', function(t) {
-    t.true(Array.isArray(features.tags), 'valid taglist');
+    t.true(typeof features === 'object' && features !== null, 'features is an object');
+    t.true('address' in features, 'has address layer');
+    t.true('venue' in features, 'has venue layer');
+    t.true(Array.isArray(features.address.tags), 'address has tags array');
+    t.true(Array.isArray(features.venue.tags), 'venue has tags array');
     t.end();
   });
 };
 
-// ensure some tags are excluded
+// ensure some tags are excluded from the venue layer
 module.exports.tests.blacklist = function(test, common) {
-  test('blacklist default tags', function(t) {
+  test('blacklist default venue tags', function(t) {
     // see: https://github.com/pelias/openstreetmap/pull/280
-    t.false( features.tags.includes('aeroway+name') );
-    t.false( features.tags.includes('aeroway~gate+name') );
-    t.false( features.tags.includes('railway+name') );
-    t.false( features.tags.includes('railway~rail+name') );
+    t.false( features.venue.tags.includes('aeroway+name') );
+    t.false( features.venue.tags.includes('aeroway~gate+name') );
+    t.false( features.venue.tags.includes('railway+name') );
+    t.false( features.venue.tags.includes('railway~rail+name') );
     t.end();
   });
 };
 
-// ensure some tags are included
-// we exclude by default tags corresponding to venues
-module.exports.tests.whitelist = function(test, common) {
-  test('whitelist default tags', function(t) {
-    t.true( features.tags.includes('addr:housenumber+addr:street') );
-    t.false( features.tags.includes('amenity+name') );
+// ensure address tags are correct
+module.exports.tests.whitelist_address = function(test, common) {
+  test('whitelist address tags', function(t) {
+    t.true( features.address.tags.includes('addr:housenumber+addr:street') );
+    t.false( features.address.tags.includes('amenity+name') );
     t.end();
   });
 };
 
-// ensure some venue tags are included
+// ensure venue tags are included
 module.exports.tests.whitelist_venue_tags = function(test, common) {
   test('whitelist venue tags', function(t) {
-    t.true( features.venue_tags.includes('amenity+name') );
-    t.true( features.venue_tags.includes('building+name') );
-    t.true( features.venue_tags.includes('shop+name') );
-    t.true( features.venue_tags.includes('office+name') );
-    t.true( features.venue_tags.includes('public_transport+name') );
-    t.true( features.venue_tags.includes('cuisine+name') );
-    t.true( features.venue_tags.includes('railway~tram_stop+name') );
-    t.true( features.venue_tags.includes('railway~station+name') );
-    t.true( features.venue_tags.includes('railway~halt+name') );
-    t.true( features.venue_tags.includes('railway~subway_entrance+name') );
-    t.true( features.venue_tags.includes('railway~train_station_entrance+name') );
-    t.true( features.venue_tags.includes('sport+name') );
-    t.true( features.venue_tags.includes('natural+name') );
-    t.true( features.venue_tags.includes('tourism+name') );
-    t.true( features.venue_tags.includes('leisure+name') );
-    t.true( features.venue_tags.includes('historic+name') );
-    t.true( features.venue_tags.includes('man_made+name') );
-    t.true( features.venue_tags.includes('landuse+name') );
-    t.true( features.venue_tags.includes('waterway+name') );
-    t.true( features.venue_tags.includes('aerialway+name') );
-    t.true( features.venue_tags.includes('craft+name') );
-    t.true( features.venue_tags.includes('military+name') );
-    t.true( features.venue_tags.includes('aeroway~terminal+name') );
-    t.true( features.venue_tags.includes('aeroway~aerodrome+name') );
-    t.true( features.venue_tags.includes('aeroway~helipad+name') );
-    t.true( features.venue_tags.includes('aeroway~airstrip+name') );
-    t.true( features.venue_tags.includes('aeroway~heliport+name') );
-    t.true( features.venue_tags.includes('aeroway~areodrome+name') );
-    t.true( features.venue_tags.includes('aeroway~spaceport+name') );
-    t.true( features.venue_tags.includes('aeroway~landing_strip+name') );
-    t.true( features.venue_tags.includes('aeroway~airfield+name') );
-    t.true( features.venue_tags.includes('aeroway~airport+name') );
-    t.true( features.venue_tags.includes('brand+name') );
-    t.true( features.venue_tags.includes('healthcare+name') );
+    t.true( features.venue.tags.includes('amenity+name') );
+    t.true( features.venue.tags.includes('building+name') );
+    t.true( features.venue.tags.includes('shop+name') );
+    t.true( features.venue.tags.includes('office+name') );
+    t.true( features.venue.tags.includes('public_transport+name') );
+    t.true( features.venue.tags.includes('cuisine+name') );
+    t.true( features.venue.tags.includes('railway~tram_stop+name') );
+    t.true( features.venue.tags.includes('railway~station+name') );
+    t.true( features.venue.tags.includes('railway~halt+name') );
+    t.true( features.venue.tags.includes('railway~subway_entrance+name') );
+    t.true( features.venue.tags.includes('railway~train_station_entrance+name') );
+    t.true( features.venue.tags.includes('sport+name') );
+    t.true( features.venue.tags.includes('natural+name') );
+    t.true( features.venue.tags.includes('tourism+name') );
+    t.true( features.venue.tags.includes('leisure+name') );
+    t.true( features.venue.tags.includes('historic+name') );
+    t.true( features.venue.tags.includes('man_made+name') );
+    t.true( features.venue.tags.includes('landuse+name') );
+    t.true( features.venue.tags.includes('waterway+name') );
+    t.true( features.venue.tags.includes('aerialway+name') );
+    t.true( features.venue.tags.includes('craft+name') );
+    t.true( features.venue.tags.includes('military+name') );
+    t.true( features.venue.tags.includes('aeroway~terminal+name') );
+    t.true( features.venue.tags.includes('aeroway~aerodrome+name') );
+    t.true( features.venue.tags.includes('aeroway~helipad+name') );
+    t.true( features.venue.tags.includes('aeroway~airstrip+name') );
+    t.true( features.venue.tags.includes('aeroway~heliport+name') );
+    t.true( features.venue.tags.includes('aeroway~areodrome+name') );
+    t.true( features.venue.tags.includes('aeroway~spaceport+name') );
+    t.true( features.venue.tags.includes('aeroway~landing_strip+name') );
+    t.true( features.venue.tags.includes('aeroway~airfield+name') );
+    t.true( features.venue.tags.includes('aeroway~airport+name') );
+    t.true( features.venue.tags.includes('brand+name') );
+    t.true( features.venue.tags.includes('healthcare+name') );
     t.end();
   });
 };

--- a/test/config/features.js
+++ b/test/config/features.js
@@ -2,14 +2,20 @@ const features = require('../../config/features');
 
 module.exports.tests = {};
 
-// test exports
 module.exports.tests.interface = function(test, common) {
   test('interface: features', function(t) {
-    t.true(typeof features === 'object' && features !== null, 'features is an object');
-    t.true('address' in features, 'has address layer');
-    t.true('venue' in features, 'has venue layer');
-    t.true(Array.isArray(features.address.tags), 'address has tags array');
-    t.true(Array.isArray(features.venue.tags), 'venue has tags array');
+    t.true(Array.isArray(features.addressTags), 'has addressTags array');
+    t.true(typeof features.layers === 'object' && features.layers !== null, 'has layers object');
+    t.true('venue' in features.layers, 'has venue layer');
+    t.true(Array.isArray(features.layers.venue.tags), 'venue has tags array');
+    t.end();
+  });
+};
+
+module.exports.tests.addressTags = function(test, common) {
+  test('addressTags: includes expected tags', function(t) {
+    t.true( features.addressTags.includes('addr:housenumber+addr:street') );
+    t.true( features.addressTags.includes('addr:housenumber+addr:place') );
     t.end();
   });
 };
@@ -18,60 +24,50 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.blacklist = function(test, common) {
   test('blacklist default venue tags', function(t) {
     // see: https://github.com/pelias/openstreetmap/pull/280
-    t.false( features.venue.tags.includes('aeroway+name') );
-    t.false( features.venue.tags.includes('aeroway~gate+name') );
-    t.false( features.venue.tags.includes('railway+name') );
-    t.false( features.venue.tags.includes('railway~rail+name') );
+    t.false( features.layers.venue.tags.includes('aeroway+name') );
+    t.false( features.layers.venue.tags.includes('aeroway~gate+name') );
+    t.false( features.layers.venue.tags.includes('railway+name') );
+    t.false( features.layers.venue.tags.includes('railway~rail+name') );
     t.end();
   });
 };
 
-// ensure address tags are correct
-module.exports.tests.whitelist_address = function(test, common) {
-  test('whitelist address tags', function(t) {
-    t.true( features.address.tags.includes('addr:housenumber+addr:street') );
-    t.false( features.address.tags.includes('amenity+name') );
-    t.end();
-  });
-};
-
-// ensure venue tags are included
 module.exports.tests.whitelist_venue_tags = function(test, common) {
   test('whitelist venue tags', function(t) {
-    t.true( features.venue.tags.includes('amenity+name') );
-    t.true( features.venue.tags.includes('building+name') );
-    t.true( features.venue.tags.includes('shop+name') );
-    t.true( features.venue.tags.includes('office+name') );
-    t.true( features.venue.tags.includes('public_transport+name') );
-    t.true( features.venue.tags.includes('cuisine+name') );
-    t.true( features.venue.tags.includes('railway~tram_stop+name') );
-    t.true( features.venue.tags.includes('railway~station+name') );
-    t.true( features.venue.tags.includes('railway~halt+name') );
-    t.true( features.venue.tags.includes('railway~subway_entrance+name') );
-    t.true( features.venue.tags.includes('railway~train_station_entrance+name') );
-    t.true( features.venue.tags.includes('sport+name') );
-    t.true( features.venue.tags.includes('natural+name') );
-    t.true( features.venue.tags.includes('tourism+name') );
-    t.true( features.venue.tags.includes('leisure+name') );
-    t.true( features.venue.tags.includes('historic+name') );
-    t.true( features.venue.tags.includes('man_made+name') );
-    t.true( features.venue.tags.includes('landuse+name') );
-    t.true( features.venue.tags.includes('waterway+name') );
-    t.true( features.venue.tags.includes('aerialway+name') );
-    t.true( features.venue.tags.includes('craft+name') );
-    t.true( features.venue.tags.includes('military+name') );
-    t.true( features.venue.tags.includes('aeroway~terminal+name') );
-    t.true( features.venue.tags.includes('aeroway~aerodrome+name') );
-    t.true( features.venue.tags.includes('aeroway~helipad+name') );
-    t.true( features.venue.tags.includes('aeroway~airstrip+name') );
-    t.true( features.venue.tags.includes('aeroway~heliport+name') );
-    t.true( features.venue.tags.includes('aeroway~areodrome+name') );
-    t.true( features.venue.tags.includes('aeroway~spaceport+name') );
-    t.true( features.venue.tags.includes('aeroway~landing_strip+name') );
-    t.true( features.venue.tags.includes('aeroway~airfield+name') );
-    t.true( features.venue.tags.includes('aeroway~airport+name') );
-    t.true( features.venue.tags.includes('brand+name') );
-    t.true( features.venue.tags.includes('healthcare+name') );
+    t.true( features.layers.venue.tags.includes('amenity+name') );
+    t.true( features.layers.venue.tags.includes('building+name') );
+    t.true( features.layers.venue.tags.includes('shop+name') );
+    t.true( features.layers.venue.tags.includes('office+name') );
+    t.true( features.layers.venue.tags.includes('public_transport+name') );
+    t.true( features.layers.venue.tags.includes('cuisine+name') );
+    t.true( features.layers.venue.tags.includes('railway~tram_stop+name') );
+    t.true( features.layers.venue.tags.includes('railway~station+name') );
+    t.true( features.layers.venue.tags.includes('railway~halt+name') );
+    t.true( features.layers.venue.tags.includes('railway~subway_entrance+name') );
+    t.true( features.layers.venue.tags.includes('railway~train_station_entrance+name') );
+    t.true( features.layers.venue.tags.includes('sport+name') );
+    t.true( features.layers.venue.tags.includes('natural+name') );
+    t.true( features.layers.venue.tags.includes('tourism+name') );
+    t.true( features.layers.venue.tags.includes('leisure+name') );
+    t.true( features.layers.venue.tags.includes('historic+name') );
+    t.true( features.layers.venue.tags.includes('man_made+name') );
+    t.true( features.layers.venue.tags.includes('landuse+name') );
+    t.true( features.layers.venue.tags.includes('waterway+name') );
+    t.true( features.layers.venue.tags.includes('aerialway+name') );
+    t.true( features.layers.venue.tags.includes('craft+name') );
+    t.true( features.layers.venue.tags.includes('military+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~terminal+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~aerodrome+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~helipad+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~airstrip+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~heliport+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~areodrome+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~spaceport+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~landing_strip+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~airfield+name') );
+    t.true( features.layers.venue.tags.includes('aeroway~airport+name') );
+    t.true( features.layers.venue.tags.includes('brand+name') );
+    t.true( features.layers.venue.tags.includes('healthcare+name') );
     t.end();
   });
 };

--- a/test/run.js
+++ b/test/run.js
@@ -19,7 +19,8 @@ var tests = [
   require('./stream/tag_mapper'),
   require('./stream/addresses_without_street'),
   require('./util/parseSemicolonDelimitedValues'),
-  require('./util/layerClassifier')
+  require('./util/layerClassifier'),
+  require('./util/resolveFeatures')
 ];
 
 tests.map(function(t) {

--- a/test/run.js
+++ b/test/run.js
@@ -18,6 +18,7 @@ var tests = [
   require('./stream/stats'),
   require('./stream/tag_mapper'),
   require('./stream/addresses_without_street'),
+  require('./stream/venueFilter'),
   require('./util/parseSemicolonDelimitedValues'),
   require('./util/layerClassifier'),
   require('./util/resolveFeatures')

--- a/test/run.js
+++ b/test/run.js
@@ -18,7 +18,8 @@ var tests = [
   require('./stream/stats'),
   require('./stream/tag_mapper'),
   require('./stream/addresses_without_street'),
-  require('./util/parseSemicolonDelimitedValues')
+  require('./util/parseSemicolonDelimitedValues'),
+  require('./util/layerClassifier')
 ];
 
 tests.map(function(t) {

--- a/test/stream/document_constructor.js
+++ b/test/stream/document_constructor.js
@@ -26,11 +26,33 @@ module.exports.tests.instantiate = function(test, common) {
     stream.pipe( through.obj( function( doc, enc, next ){
       t.equal( Object.getPrototypeOf(doc), Document.prototype, 'correct proto' );
       t.equal( doc.getId(), 'X/1', 'correct id' );
-      t.equal( doc.getLayer(), 'venue', 'defaults to venue' );
+      t.equal( doc.getLayer(), 'venue', 'defaults to venue when no tags match' );
       t.end(); // test will fail if not called (or called twice).
       next();
     }));
     stream.write({ id: 1, type: 'X' });
+  });
+};
+
+module.exports.tests.layer_classification = function(test, common) {
+  test('layer: address tags produce address layer', function(t) {
+    var stream = constructor();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal( doc.getLayer(), 'address', 'classified as address' );
+      t.end();
+      next();
+    }));
+    stream.write({ id: 1, type: 'node', tags: { 'addr:housenumber': '123', 'addr:street': 'Main St' } });
+  });
+
+  test('layer: venue tags produce venue layer', function(t) {
+    var stream = constructor();
+    stream.pipe( through.obj( function( doc, enc, next ){
+      t.equal( doc.getLayer(), 'venue', 'classified as venue' );
+      t.end();
+      next();
+    }));
+    stream.write({ id: 2, type: 'node', tags: { amenity: 'cafe', name: 'Bean There' } });
   });
 };
 

--- a/test/stream/document_constructor.js
+++ b/test/stream/document_constructor.js
@@ -35,10 +35,10 @@ module.exports.tests.instantiate = function(test, common) {
 };
 
 module.exports.tests.layer_classification = function(test, common) {
-  test('layer: address tags produce address layer', function(t) {
+  test('layer: address tags default to venue (address_extractor assigns address downstream)', function(t) {
     var stream = constructor();
     stream.pipe( through.obj( function( doc, enc, next ){
-      t.equal( doc.getLayer(), 'address', 'classified as address' );
+      t.equal( doc.getLayer(), 'venue', 'address records start as venue' );
       t.end();
       next();
     }));

--- a/test/stream/importPipeline.js
+++ b/test/stream/importPipeline.js
@@ -15,6 +15,7 @@ module.exports.tests.interface = function(test, common) {
     'tagMapper',
     'adminLookup',
     'addressExtractor',
+    'venueFilter',
     'categoryMapper',
     'addendumMapper',
     'popularityMapper',

--- a/test/stream/pbf.js
+++ b/test/stream/pbf.js
@@ -1,7 +1,6 @@
 var path = require('path');
 var through = require('through2');
 var settings = require('pelias-config').generate();
-var features = require('../../config/features');
 var proxyquire = require('proxyquire');
 
 var fakeGeneratedConfig = {

--- a/test/stream/venueFilter.js
+++ b/test/stream/venueFilter.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const through = require('through2');
+const proxyquire = require('proxyquire');
+
+module.exports.tests = {};
+
+function makeFakeConfig(importVenues) {
+  return {
+    generate: () => ({
+      imports: {
+        openstreetmap: {
+          import: [{ filename: 'test.pbf', importVenues }]
+        }
+      }
+    })
+  };
+}
+
+function makeDoc(layer) {
+  return { getLayer: () => layer };
+}
+
+module.exports.tests.interface = function(test, common) {
+  test('interface: factory', function(t) {
+    const venueFilter = proxyquire('../../stream/venueFilter', {
+      'pelias-config': makeFakeConfig(true)
+    });
+    t.equal(typeof venueFilter, 'function', 'stream factory');
+    t.end();
+  });
+};
+
+module.exports.tests.importVenues_true = function(test, common) {
+  test('importVenues: true passes all records through', function(t) {
+    const venueFilter = proxyquire('../../stream/venueFilter', {
+      'pelias-config': makeFakeConfig(true)
+    });
+    const stream = venueFilter();
+    const results = [];
+    stream.pipe(through.obj((doc, enc, next) => { results.push(doc); next(); }));
+    stream.write(makeDoc('venue'));
+    stream.write(makeDoc('address'));
+    stream.end(() => {
+      t.equal(results.length, 2, 'both records passed through');
+      t.end();
+    });
+  });
+};
+
+module.exports.tests.importVenues_false = function(test, common) {
+  test('importVenues: false drops venue records', function(t) {
+    const venueFilter = proxyquire('../../stream/venueFilter', {
+      'pelias-config': makeFakeConfig(false)
+    });
+    const stream = venueFilter();
+    const results = [];
+    stream.pipe(through.obj((doc, enc, next) => { results.push(doc); next(); }));
+    stream.write(makeDoc('venue'));
+    stream.write(makeDoc('address'));
+    stream.write(makeDoc('venue'));
+    stream.end(() => {
+      t.equal(results.length, 1, 'only address record passed through');
+      t.equal(results[0].getLayer(), 'address', 'correct record kept');
+      t.end();
+    });
+  });
+
+  test('importVenues: false passes custom layer records through', function(t) {
+    const venueFilter = proxyquire('../../stream/venueFilter', {
+      'pelias-config': makeFakeConfig(false)
+    });
+    const stream = venueFilter();
+    const results = [];
+    stream.pipe(through.obj((doc, enc, next) => { results.push(doc); next(); }));
+    stream.write(makeDoc('address'));
+    stream.write(makeDoc('protected_area'));
+    stream.end(() => {
+      t.equal(results.length, 1, 'only address passed; custom layers also dropped when venues off');
+      t.end();
+    });
+  });
+};
+
+module.exports.all = function(tape, common) {
+  function test(name, testFunction) {
+    return tape('venueFilter: ' + name, testFunction);
+  }
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/util/layerClassifier.js
+++ b/test/util/layerClassifier.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const { patternMatchesTags, classify } = require('../../util/layerClassifier');
+
+module.exports.tests = {};
+
+module.exports.tests.patternMatchesTags = function(test, common) {
+  test('key existence: matches when key present', function(t) {
+    t.true(patternMatchesTags('name', { name: 'foo' }));
+    t.end();
+  });
+
+  test('key existence: no match when key absent', function(t) {
+    t.false(patternMatchesTags('name', {}));
+    t.end();
+  });
+
+  test('key=value: matches when key equals value', function(t) {
+    t.true(patternMatchesTags('railway~station', { railway: 'station' }));
+    t.end();
+  });
+
+  test('key=value: no match when value differs', function(t) {
+    t.false(patternMatchesTags('railway~station', { railway: 'bus_stop' }));
+    t.end();
+  });
+
+  test('key=value: no match when key absent', function(t) {
+    t.false(patternMatchesTags('railway~station', {}));
+    t.end();
+  });
+
+  test('multi-condition AND: all conditions must match', function(t) {
+    t.true(patternMatchesTags('amenity+name', { amenity: 'cafe', name: 'Bean There' }));
+    t.end();
+  });
+
+  test('multi-condition AND: fails if any condition missing', function(t) {
+    t.false(patternMatchesTags('amenity+name', { amenity: 'cafe' }));
+    t.end();
+  });
+
+  test('three-part pattern with value conditions', function(t) {
+    t.true(patternMatchesTags('highway~pedestrian+area~yes+name', {
+      highway: 'pedestrian', area: 'yes', name: 'Market Square'
+    }));
+    t.false(patternMatchesTags('highway~pedestrian+area~yes+name', {
+      highway: 'pedestrian', area: 'yes'
+    }));
+    t.false(patternMatchesTags('highway~pedestrian+area~yes+name', {
+      highway: 'pedestrian', name: 'Market Square'
+    }));
+    t.end();
+  });
+};
+
+module.exports.tests.classify = function(test, common) {
+  const fakeFeatures = {
+    address: { tags: ['addr:housenumber+addr:street'] },
+    venue:   { tags: ['amenity+name', 'leisure+name'] },
+    river:   { tags: ['waterway~river+name'] }
+  };
+
+  test('classify: matches address layer', function(t) {
+    t.equal(classify({ 'addr:housenumber': '1', 'addr:street': 'Main St' }, fakeFeatures), 'address');
+    t.end();
+  });
+
+  test('classify: matches venue layer', function(t) {
+    t.equal(classify({ amenity: 'cafe', name: 'Bean There' }, fakeFeatures), 'venue');
+    t.end();
+  });
+
+  test('classify: matches custom layer', function(t) {
+    t.equal(classify({ waterway: 'river', name: 'Sacramento River' }, fakeFeatures), 'river');
+    t.end();
+  });
+
+  test('classify: falls back to venue when no match', function(t) {
+    t.equal(classify({ foo: 'bar' }, fakeFeatures), 'venue');
+    t.end();
+  });
+
+  test('classify: falls back to venue for empty tags', function(t) {
+    t.equal(classify({}, fakeFeatures), 'venue');
+    t.end();
+  });
+
+  test('classify: address layer has priority over venue when both could match', function(t) {
+    // address is declared before venue in fakeFeatures, so it wins
+    const tags = { 'addr:housenumber': '1', 'addr:street': 'Main St', amenity: 'cafe', name: 'Cafe' };
+    t.equal(classify(tags, fakeFeatures), 'address');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('layerClassifier: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/util/layerClassifier.js
+++ b/test/util/layerClassifier.js
@@ -55,17 +55,11 @@ module.exports.tests.patternMatchesTags = function(test, common) {
 };
 
 module.exports.tests.classify = function(test, common) {
-  // venue is listed before address, mirroring real features.js ordering
+  // address is not a layer in real features.js; these fakeFeatures test the generic classifier
   const fakeFeatures = {
     venue:   { tags: ['amenity+name', 'leisure+name'] },
-    address: { tags: ['addr:housenumber+addr:street'] },
     river:   { tags: ['waterway~river+name'] }
   };
-
-  test('classify: matches address layer', function(t) {
-    t.equal(classify({ 'addr:housenumber': '1', 'addr:street': 'Main St' }, fakeFeatures), 'address');
-    t.end();
-  });
 
   test('classify: matches venue layer', function(t) {
     t.equal(classify({ amenity: 'cafe', name: 'Bean There' }, fakeFeatures), 'venue');
@@ -87,25 +81,17 @@ module.exports.tests.classify = function(test, common) {
     t.end();
   });
 
-  test('classify: venue layer has priority over address when both could match', function(t) {
-    // venue is declared before address in fakeFeatures (and real features.js), so named POIs
-    // with address tags get classified as venue, not address
-    const tags = { 'addr:housenumber': '1', 'addr:street': 'Main St', amenity: 'cafe', name: 'Cafe' };
+  test('classify: first declared layer wins when multiple match', function(t) {
+    // if a record matches both venue and river, venue wins because it is declared first
+    const tags = { amenity: 'cafe', name: 'Riverside Cafe', waterway: 'river' };
     t.equal(classify(tags, fakeFeatures), 'venue');
     t.end();
   });
 
-  test('classify: named record with address but no specific venue tag returns address from classifier', function(t) {
-    // the classifier returns 'address' here; document_constructor overrides this to 'venue'
-    // since address_extractor handles address layer assignment downstream
+  test('classify: named address-only record falls back to venue (no address layer in real config)', function(t) {
+    // in real usage features.layers has no address key; these fall back to venue
     const tags = { 'addr:housenumber': '123', 'addr:street': 'Main St', name: 'Dry Creek Landfill' };
-    t.equal(classify(tags, fakeFeatures), 'address');
-    t.end();
-  });
-
-  test('classify: unnamed address record gets address layer', function(t) {
-    const tags = { 'addr:housenumber': '123', 'addr:street': 'Main St' };
-    t.equal(classify(tags, fakeFeatures), 'address');
+    t.equal(classify(tags, fakeFeatures), 'venue');
     t.end();
   });
 };

--- a/test/util/layerClassifier.js
+++ b/test/util/layerClassifier.js
@@ -55,9 +55,10 @@ module.exports.tests.patternMatchesTags = function(test, common) {
 };
 
 module.exports.tests.classify = function(test, common) {
+  // venue is listed before address, mirroring real features.js ordering
   const fakeFeatures = {
-    address: { tags: ['addr:housenumber+addr:street'] },
     venue:   { tags: ['amenity+name', 'leisure+name'] },
+    address: { tags: ['addr:housenumber+addr:street'] },
     river:   { tags: ['waterway~river+name'] }
   };
 
@@ -86,9 +87,24 @@ module.exports.tests.classify = function(test, common) {
     t.end();
   });
 
-  test('classify: address layer has priority over venue when both could match', function(t) {
-    // address is declared before venue in fakeFeatures, so it wins
+  test('classify: venue layer has priority over address when both could match', function(t) {
+    // venue is declared before address in fakeFeatures (and real features.js), so named POIs
+    // with address tags get classified as venue, not address
     const tags = { 'addr:housenumber': '1', 'addr:street': 'Main St', amenity: 'cafe', name: 'Cafe' };
+    t.equal(classify(tags, fakeFeatures), 'venue');
+    t.end();
+  });
+
+  test('classify: named record with address but no specific venue tag returns address from classifier', function(t) {
+    // the classifier returns 'address' here; document_constructor overrides this to 'venue'
+    // since address_extractor handles address layer assignment downstream
+    const tags = { 'addr:housenumber': '123', 'addr:street': 'Main St', name: 'Dry Creek Landfill' };
+    t.equal(classify(tags, fakeFeatures), 'address');
+    t.end();
+  });
+
+  test('classify: unnamed address record gets address layer', function(t) {
+    const tags = { 'addr:housenumber': '123', 'addr:street': 'Main St' };
     t.equal(classify(tags, fakeFeatures), 'address');
     t.end();
   });

--- a/test/util/resolveFeatures.js
+++ b/test/util/resolveFeatures.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const resolveFeatures = require('../../util/resolveFeatures');
+const defaults = require('../../config/features');
+
+module.exports.tests = {};
+
+module.exports.tests.defaults = function(test, common) {
+  test('returns defaults when no osm config present', function(t) {
+    const result = resolveFeatures({});
+    t.deepEqual(result.addressTags, defaults.addressTags, 'default addressTags');
+    t.deepEqual(result.layers, defaults.layers, 'default layers');
+    t.end();
+  });
+
+  test('returns defaults when settings is null', function(t) {
+    const result = resolveFeatures(null);
+    t.deepEqual(result.addressTags, defaults.addressTags, 'default addressTags');
+    t.deepEqual(result.layers, defaults.layers, 'default layers');
+    t.end();
+  });
+};
+
+module.exports.tests.override_addressTags = function(test, common) {
+  test('addressTags from pelias.json overrides defaults', function(t) {
+    const customTags = ['addr:housenumber+addr:street'];
+    const settings = { imports: { openstreetmap: { addressTags: customTags } } };
+    const result = resolveFeatures(settings);
+    t.deepEqual(result.addressTags, customTags, 'custom addressTags used');
+    t.deepEqual(result.layers, defaults.layers, 'layers still default');
+    t.end();
+  });
+};
+
+module.exports.tests.override_layers = function(test, common) {
+  test('layers from pelias.json overrides defaults', function(t) {
+    const customLayers = {
+      venue: { tags: ['amenity+name'] },
+      protected_area: { tags: ['boundary~protected_area+name'] }
+    };
+    const settings = { imports: { openstreetmap: { layers: customLayers } } };
+    const result = resolveFeatures(settings);
+    t.deepEqual(result.layers, customLayers, 'custom layers used');
+    t.deepEqual(result.addressTags, defaults.addressTags, 'addressTags still default');
+    t.end();
+  });
+
+  test('both addressTags and layers can be overridden together', function(t) {
+    const customTags = ['addr:housenumber+addr:street'];
+    const customLayers = { venue: { tags: ['amenity+name'] } };
+    const settings = { imports: { openstreetmap: { addressTags: customTags, layers: customLayers } } };
+    const result = resolveFeatures(settings);
+    t.deepEqual(result.addressTags, customTags, 'custom addressTags used');
+    t.deepEqual(result.layers, customLayers, 'custom layers used');
+    t.end();
+  });
+};
+
+module.exports.all = function(tape, common) {
+  function test(name, testFunction) {
+    return tape('resolveFeatures: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/util/layerClassifier.js
+++ b/util/layerClassifier.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * Test a single pbf2json tag condition against an OSM tags object.
+ * Supports 'key' (key must exist) or 'key~value' (key must equal value).
+ */
+function conditionMatchesTags(condition, tags) {
+  const tildeIdx = condition.indexOf('~');
+  if (tildeIdx === -1) {
+    return Object.prototype.hasOwnProperty.call(tags, condition);
+  }
+  const key = condition.slice(0, tildeIdx);
+  const value = condition.slice(tildeIdx + 1);
+  return tags[key] === value;
+}
+
+/**
+ * Test whether a full pbf2json pattern string matches a tags object.
+ * Pattern conditions are separated by '+' and all must match (AND logic).
+ */
+function patternMatchesTags(pattern, tags) {
+  return pattern.split('+').every(cond => conditionMatchesTags(cond, tags));
+}
+
+/**
+ * Classify an OSM tags object against the features config.
+ * Iterates layers in declaration order and returns the first matching layer.
+ * Falls back to 'venue' if no patterns match.
+ *
+ * @param {Object} tags     - OSM tags from a pbf2json record
+ * @param {Object} features - the features.js keyed-by-layer export
+ * @returns {string} layer name
+ */
+function classify(tags, features) {
+  for (const [layer, config] of Object.entries(features)) {
+    if (Array.isArray(config.tags) && config.tags.some(p => patternMatchesTags(p, tags))) {
+      return layer;
+    }
+  }
+  return 'venue';
+}
+
+module.exports = { patternMatchesTags, classify };

--- a/util/resolveFeatures.js
+++ b/util/resolveFeatures.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const defaults = require('../config/features');
+
+/**
+ * Resolve the effective features config by merging pelias.json overrides
+ * with the defaults from config/features.js.
+ *
+ * If `imports.openstreetmap.layers` is set in pelias.json it fully replaces
+ * the default layer set. Same for `addressTags`. This lets operators add
+ * custom layers (e.g. protected_area) or restrict which tags are extracted
+ * without touching the source code.
+ *
+ * @param {Object} settings - result of pelias-config generate()
+ * @returns {{ addressTags: string[], layers: Object }}
+ */
+function resolveFeatures(settings) {
+  const osmConfig = (settings && settings.imports && settings.imports.openstreetmap) || {};
+  return {
+    addressTags: osmConfig.addressTags || defaults.addressTags,
+    layers:      osmConfig.layers      || defaults.layers
+  };
+}
+
+module.exports = resolveFeatures;


### PR DESCRIPTION
This reworks how we manage layers in the OpenStreetMap importer to give much more control.

Previously, there are only two layers supported by this importer: `venue` and `address`. It was possible to change the OSM tags used to detect each layer by editing code, but that was it.

Now, any number of layers can be configured and controlled through `pelias.json`

This could be used to extend the venue layer or even add new ones. For example, to extract only coffee shops to a layer called `coffee`, you could do something like this:

```
{
  "imports": {
    "openstreetmap": {
      "layers": {
        "coffee": {
          "tags": [ "amenity~cafe+name" ]
        }
      }
    }
  }
}
```

As a nice side effect, this also should fix #515. While we had an `importVenues` flag (still supported, though technically redundant as the `venue` property in `layers` can now simply be unset), records that matched _both_ the venue and address tags would still be added as venues, even with `importVenues` set to false.