### PR TITLE
Populate taginfo file for OpenStreetmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ esclient.log
 nohup.out
 test/*.pbf
 coverage
+taginfo.json
 
 actual_output.json
 expected_output.json

--- a/config/addendum_whitelist.js
+++ b/config/addendum_whitelist.js
@@ -1,0 +1,25 @@
+
+/**
+  Tags stored verbatim in the OSM addendum of every imported record.
+
+  @see stream/addendum_mapper.js
+  @see https://github.com/pelias/api/pull/1255
+**/
+
+module.exports = [
+  'wheelchair',           // Wheelchair accessibility
+  'iata',                 // IATA airport codes
+  'icao',                 // ICAO airport codes
+  'wikidata',             // Wikidata concordance
+  'wikipedia',            // Wikipedia concordance
+  'operator',             // Operator name
+  'brand',                // Brand name
+  'website',              // Website URL
+  'phone',                // Telephone number
+  'opening_hours',        // Opening hours
+
+  // COVID-19
+  'opening_hours:covid19',
+  'delivery:covid19',
+  'safety:mask:covid19',
+];

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "end-to-end": "export NODE_ENV=test && node test/end-to-end.js;",
     "lint": "jshint .",
     "start": "./bin/start",
+    "taginfo": "node scripts/generate_taginfo.js",
+    "prepublishOnly": "npm run taginfo",
     "test": "npm run units",
     "ci": "node ./test/ci-config.js && npm test && npm run end-to-end",
     "units": "./bin/test",

--- a/scripts/generate_taginfo.js
+++ b/scripts/generate_taginfo.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Generates taginfo.json describing which OSM tags Pelias reads.
+ *
+ * Sources of truth pulled in at generation time:
+ *   - config/features.js          (venue detection tags, address filter keys)
+ *   - config/addendum_whitelist.js (metadata tags stored in the OSM addendum)
+ *   - schema/name_osm.js           (name/alias tags)
+ *   - schema/address_*.js          (address tags)
+ *
+ * Published to npm and served by jsDelivr:
+ *   https://cdn.jsdelivr.net/npm/pelias-openstreetmap/taginfo.json
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+const pkg          = require('../package.json');
+const features     = require('../config/features');
+const nameSchema   = require('../schema/name_osm');
+const karlsruhe    = require('../schema/address_karlsruhe');
+const osmAddr      = require('../schema/address_osm');
+const tiger        = require('../schema/address_tiger');
+const naptan       = require('../schema/address_naptan');
+const addendumKeys = require('../config/addendum_whitelist');
+
+const OBJECT_TYPES = ['node', 'way', 'relation'];
+
+function entry(key, description, value) {
+  const e = { key };
+  if (value !== undefined) {
+    e.value = value;
+  }
+  e.object_types = OBJECT_TYPES;
+  e.description  = description;
+  return e;
+}
+
+// ---------------------------------------------------------------------------
+// Venue detection tags — derived from config/features.js
+// Format: 'amenity+name', 'railway~station+name', 'highway~pedestrian+area~yes+name'
+// '+' = AND conditions; '~' = key=value; 'name' and 'area~yes' are secondary filters
+// ---------------------------------------------------------------------------
+function parseVenueTags(patterns) {
+  const seen    = new Set();
+  const entries = [];
+  for (const pattern of patterns) {
+    const parts = pattern.split('+').filter(p => p !== 'name' && p !== 'area~yes');
+    for (const part of parts) {
+      const [key, value] = part.split('~');
+      const id = value ? `${key}=${value}` : key;
+      if (!seen.has(id)) {
+        seen.add(id);
+        entries.push({ key, value });
+      }
+    }
+  }
+  return entries;
+}
+
+const venueTags = parseVenueTags(features.layers.venue.tags).map(({ key, value }) => {
+  const desc = value ?
+    `${key}=${value} features with a name are imported as venues` :
+    `Features with any ${key} tag and a name are imported as venues`;
+  return entry(key, desc, value);
+});
+
+// ---------------------------------------------------------------------------
+// Address tags — derived from all address schemas + features.addressTags
+// ---------------------------------------------------------------------------
+const addressDescriptions = {
+  'addr:housenumber': 'House number; required (with addr:street or addr:place) to create an address record',
+  'addr:street':      'Street name for address records',
+  'addr:place':       'Named settlement used instead of a street for rural addresses',
+  'addr:housename':   'Building or house name, imported as the address name',
+  'addr:postcode':    'Postal/ZIP code',
+  'postal_code':      'Postal code (OSM standard key, alternative to addr:postcode)',
+  'tiger:zip_left':   'US TIGER-imported postal code for the left side of the street',
+  'tiger:zip_right':  'US TIGER-imported postal code for the right side of the street',
+  'naptan:Street':    'Street name from the UK NaPTAN bus stop dataset',
+};
+
+const addressKeys = new Set([
+  ...Object.keys(karlsruhe),
+  ...Object.keys(osmAddr),
+  ...Object.keys(tiger),
+  ...Object.keys(naptan),
+  // pbf2json filter patterns like 'addr:housenumber+addr:street'
+  ...features.addressTags.flatMap(p => p.split('+')),
+]);
+
+const addressTags = [...addressKeys].map(k =>
+  entry(k, addressDescriptions[k] || 'Address field used by the Pelias OSM importer')
+);
+
+// ---------------------------------------------------------------------------
+// Name tags — derived from schema/name_osm.js
+// Localized name tags (name:en, name:fr, …) are read dynamically via iso-639-3
+// ---------------------------------------------------------------------------
+const nameDescriptions = {
+  name:       'Primary display name; the main search term for a record',
+  loc_name:   'Local name; indexed as an alias',
+  alt_name:   'Alternative name; indexed as an alias',
+  short_name: 'Short name; indexed as an alias',
+};
+
+const nameTags = [
+  ...Object.keys(nameSchema).map(k =>
+    entry(k, nameDescriptions[k] || 'Name variant indexed as an alias')
+  ),
+  // Localised names are resolved at import time from iso-639-3 (e.g. name:en, name:fr)
+  entry('name:*', 'Language-specific names (e.g. name:en, name:fr) are indexed as localized aliases'),
+];
+
+// ---------------------------------------------------------------------------
+// Addendum / metadata tags — derived from config/addendum_whitelist.js
+// ---------------------------------------------------------------------------
+const addendumTags = addendumKeys.map(k =>
+  entry(k, `${k} is stored verbatim in the OSM addendum of every imported record`)
+);
+
+// ---------------------------------------------------------------------------
+// Assemble, deduplicate (venue tags take precedence), and write
+// ---------------------------------------------------------------------------
+const seen = new Set();
+const tags = [...venueTags, ...addressTags, ...nameTags, ...addendumTags].filter(t => {
+  const id = t.value !== undefined ? `${t.key}=${t.value}` : t.key;
+  if (seen.has(id)) {
+    return false;
+  }
+  seen.add(id);
+  return true;
+});
+
+const output = {
+  data_format: 1,
+  data_url: `https://cdn.jsdelivr.net/npm/${pkg.name}/taginfo.json`,
+  project: {
+    name:          'Pelias Geocoder — OpenStreetMap importer',
+    description:   'Imports OpenStreetMap data into the Pelias geocoding engine',
+    project_url:   pkg.homepage,
+    doc_url:       `${pkg.homepage}#readme`,
+    icon_url:      'https://github.com/pelias.png',
+    contact_name:  'Pelias Team',
+    contact_email: 'team@pelias.io',
+  },
+  tags,
+};
+
+const outPath = path.join(__dirname, '..', 'taginfo.json');
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + '\n');
+console.log(`taginfo.json written (${tags.length} tag entries)`);

--- a/stream/addendum_mapper.js
+++ b/stream/addendum_mapper.js
@@ -7,23 +7,7 @@
 
 const through = require('through2');
 const peliasLogger = require('pelias-logger').get('openstreetmap');
-const whitelist = [
-  'wheelchair', // Wheelchair accessibility
-  'iata', // IATA airport codes
-  'icao', // ICAO airport codes
-  'wikidata', // Wikidata concordance
-  'wikipedia', // Wikipedia concordance
-  'operator', // Operator name
-  'brand', // Brand name
-  'website', // Website URL
-  'phone', // Telephone number
-  'opening_hours', // Opening hours
-
-  // COVID-19
-  'opening_hours:covid19',
-  'delivery:covid19',
-  'safety:mask:covid19'
-];
+const whitelist = require('../config/addendum_whitelist');
 
 module.exports = function(){
 


### PR DESCRIPTION
This adds a simple script that generates a taginfo schema for the Pelias OSM importer.

It runs before NPM publish, so the taginfo file will be included in NPM packages.

This is so that we can use a link to something like https://cdn.jsdelivr.net/npm/pelias-openstreetmap/taginfo.json as a permalink. Since the script runs automatically and reads directly from tag uses in the code, we never have to remember to run anything manually.

Some minor refactoring was required to achieve this, but the importer functionality is unchanged.

Closes https://github.com/pelias/openstreetmap/issues/579