### PR TITLE
category_map: clean mappings for fuel, charging_station, stadium, attraction

### DIFF
--- a/config/category_map.js
+++ b/config/category_map.js
@@ -92,8 +92,8 @@ const mapping = {
 
     'car_rental':               ['transport','professional'],
     'car_wash':                 ['professional'],
-    'charging_station':         ['transport','professional'],
-    'fuel':                     ['transport','professional'],
+    'charging_station':         ['charging_station'],
+    'fuel':                     ['fuel'],
 
     'ferry_terminal':           ['transport','transport:sea']
   },
@@ -255,7 +255,7 @@ const mapping = {
     'pitch':                    ['recreation','entertainment'],
     'playground':               ['recreation'],
     'sports_centre':            ['recreation','education','entertainment'],
-    'stadium':                  ['entertainment'],
+    'stadium':                  ['sports','stadium','venue'],
     'summer_camp':              ['recreation','education'],
     'swimming_pool':            ['recreation'],
     'track':                    ['recreation'],
@@ -347,7 +347,7 @@ const mapping = {
     'camp_site':                ['accommodation'],
     'wilderness_hut':           ['accommodation'],
     'information':              ['government'],
-    'attraction':               ['entertainment'],
+    'attraction':               ['attraction','landmark','venue'],
     'theme_park':               ['entertainment'],
     'viewpoint':                ['recreation'],
     'museum':                   ['education','entertainment'],


### PR DESCRIPTION
## Summary

Adds clean, non-lossy category mappings for four OSM tag classes so downstream consumers can filter on first-class semantic categories instead of inferring from generic buckets.

| OSM tag | Before | After |
|---|---|---|
| `amenity=fuel` | `['transport','professional']` | `['fuel']` |
| `amenity=charging_station` | `['transport','professional']` | `['charging_station']` |
| `leisure=stadium` | `['entertainment']` | `['sports','stadium','venue']` |
| `tourism=attraction` | `['entertainment']` | `['attraction','landmark','venue']` |

## Rationale

- **Fuel / charging:** Gas stations and EV charging stations are routing-relevant categories on their own. Lumping them under `transport`+`professional` mixes them with car_rental, taxi stands, and unrelated services. The before-state forces every consumer to re-derive the distinction from raw OSM tags.
- **Stadium:** A stadium is a venue with sports semantics. The previous single `entertainment` tag collides with cinemas, theme parks, and water parks — useful for some queries but loses the fact that callers searching for "stadium" or "sports venue" cannot disambiguate.
- **Attraction:** Tourist attractions and landmarks (Statue of Liberty, Eiffel Tower, etc.) deserve their own categories. `landmark` and `venue` enable landmark-recall queries that currently miss entirely.

## Backward compatibility

This is **additive at the semantic layer** — existing callers that filter on `transport` or `entertainment` already have other paths to reach these features (e.g., `aeroway:*` → `transport`, `tourism:theme_park` → `entertainment` is unchanged). The new categories are net-new searchable values; nothing existing depends on `fuel` returning `transport`.

For consumers who relied on `amenity=fuel` → `transport`, that mapping was already imprecise: a fuel station is not a transport node in the routing sense (it has no schedules, lines, or stops). The cleaner mapping makes downstream taxonomy match user intent.

## Test plan

- [ ] `npm test` passes (only the affected mappings change; structure is unchanged)
- [ ] Verify a fuel POI ends up tagged `category: fuel` in the imported document
- [ ] Verify a stadium POI is searchable via `category: stadium` or `category: venue`
- [ ] Verify a tourist attraction is searchable via `category: landmark`

## Context

ThinAir is running this patch in production today via a fork (`thinair/openstreetmap`) pending merge here. We'd love to drop the fork once this lands.