### PR TITLE
Remove name:* from taginfo output

### DIFF
--- a/scripts/generate_taginfo.js
+++ b/scripts/generate_taginfo.js
@@ -110,8 +110,6 @@ const nameTags = [
   ...Object.keys(nameSchema).map(k =>
     entry(k, nameDescriptions[k] || 'Name variant indexed as an alias')
   ),
-  // Localised names are resolved at import time from iso-639-3 (e.g. name:en, name:fr)
-  entry('name:*', 'Language-specific names (e.g. name:en, name:fr) are indexed as localized aliases'),
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
As per the taginfo project documentation do not use wildcard characters in any fields. A * is a literal asterisk character.

I don't have the test environment set up to test this change.