### PR TITLE
harden: sanitize child_process call in download_data.js...

### DIFF
--- a/util/download_data.js
+++ b/util/download_data.js
@@ -52,7 +52,7 @@ function downloadSource(config, sourceUrl, callback) {
   const targetDir = config.imports.openstreetmap.datapath;
 
   logger.debug(`downloading ${sourceUrl} to ${targetDir}`);
-  child_process.exec(`cd ${targetDir} && { curl -L -X GET --silent --fail --remote-name ${sourceUrl}; }`, callback);
+  child_process.execFile('curl', ['-L', '-X', 'GET', '--silent', '--fail', '--remote-name', sourceUrl], { cwd: targetDir }, callback);
 }
 
 module.exports = download;


### PR DESCRIPTION
## Summary
Harden input handling in `util/download_data.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `util/download_data.js:55` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `config`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `util/download_data.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
